### PR TITLE
Add methodology note for Artemis Fee Payers metric

### DIFF
--- a/providers/artemis.py
+++ b/providers/artemis.py
@@ -21,15 +21,21 @@ from providers.base import BaseProvider
 class Artemis(BaseProvider):
     """Fetch stablecoin metrics from the Artemis XYZ API."""
 
-    METRIC_MAP: Dict[str, str] = {
-        "stablecoin_supply": "STABLECOIN_SUPPLY",
-        "stablecoin_transfer_volume": "STABLECOIN_TRANSFER_VOLUME",
-        "stablecoin_transfer_count": "STABLECOIN_DAILY_TXNS",
-        "stablecoin_active_addresses": "STABLECOIN_DAU",
-        "overview_fee_payers": "DAU",
-        "overview_sol_price": "PRICE",
-        "overview_fees": "FEES_NATIVE",
-        "defi_dex_volume": "CHAIN_SPOT_VOLUME",
+    METRIC_MAP: Dict[str, Dict[str, Any]] = {
+        "stablecoin_supply": {"endpoint": "STABLECOIN_SUPPLY"},
+        "stablecoin_transfer_volume": {"endpoint": "STABLECOIN_TRANSFER_VOLUME"},
+        "stablecoin_transfer_count": {"endpoint": "STABLECOIN_DAILY_TXNS"},
+        "stablecoin_active_addresses": {"endpoint": "STABLECOIN_DAU"},
+        "overview_fee_payers": {
+            "endpoint": "DAU",
+            "methodology": (
+                "Distinct signers of successful transactions, not just fee "
+                "payers, capturing fee-sponsored users."
+            ),
+        },
+        "overview_sol_price": {"endpoint": "PRICE"},
+        "overview_fees": {"endpoint": "FEES_NATIVE"},
+        "defi_dex_volume": {"endpoint": "CHAIN_SPOT_VOLUME"},
     }
     BASE_URL = "https://data-svc.artemisxyz.com"
 
@@ -67,7 +73,7 @@ class Artemis(BaseProvider):
         self, metric: str, start_date: str, end_date: str, chain: str = "solana"
     ) -> List[Dict[str, Any]]:
         """Return normalized {"date": str, "value": Any} records for the given range (both dates inclusive)."""
-        endpoint = self.METRIC_MAP[metric]
+        endpoint = self.METRIC_MAP[metric]["endpoint"]
         body = self._get(
             endpoint,
             params={"symbols": chain, "startDate": start_date, "endDate": end_date},


### PR DESCRIPTION
Adds a methodology note for the Artemis **Fee Payers** metric, surfaced via `python main.py --methodology`.

### Context
Artemis's Fee Payers series is backed by our **DAU** metric, which on Solana counts **distinct signers of successful transactions** (every transaction signer, not only the fee-paying signer at account index 0). This is a deliberate, long-standing methodology choice: many Solana apps pay transaction fees on behalf of their users (fee sponsorship), so counting only the fee payer undercounts those users. The trade-off is that this approach yields higher counts than fee-payer-only methodologies (e.g. ~1.8-2x the index-0 fee-payer count).

This documents that difference so the gap vs other providers is explained rather than surprising.

### Change
- Adds a `methodology` note to `overview_fee_payers` in the Artemis provider.
- Reshapes the Artemis `METRIC_MAP` from a flat `Dict[str, str]` to the `{"endpoint": ..., "methodology": ...}` dict shape already used by the other providers, so `build_methodology()` picks up the note. `fetch_rows` updated to read `["endpoint"]` accordingly.

### Verification
- `make lint` clean (ruff + black)
- `make test` — 33/33 unit tests pass
- `python main.py --methodology` emits the new record

🤖 Generated with [Claude Code](https://claude.com/claude-code)
