### PR TITLE
Add Zerion data provider (daily SOL price)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+# Copy to .env and fill in the keys for the providers you want to run.
+# Providers without a key set are skipped automatically. Stakewiz needs no key.
+
+ALLIUM_API_KEY=
+ARTEMIS_API_KEY=
+BLOCKWORKS_API_KEY=
+DEFILLAMA_API_KEY=
+DUNE_API_KEY=
+RWA_API_KEY=
+TOKEN_TERMINAL_API_KEY=
+VALIDATORS_APP_API_TOKEN=
+ZERION_API_KEY=

--- a/README.md
+++ b/README.md
@@ -18,10 +18,11 @@ Prefix the with `[Backfill]` indicating the following:
 - Python 3.12+
 - `pip` and `venv`
 - API keys for the providers you want to run (see `.env.example`)
+  - `ZERION_API_KEY` enables the Zerion provider (free key at [dashboard.zerion.io](https://dashboard.zerion.io))
 
 ## Project Layout
 - `metrics/`: typed metric models and metadata mapping
-- `providers/`: provider interfaces (Allium, Artemis, Blockworks, DefiLlama, Dune, RWA, Stakewiz, TokenTerminal, ValidatorsApp)
+- `providers/`: provider interfaces (Allium, Artemis, Blockworks, DefiLlama, Dune, RWA, Stakewiz, TokenTerminal, ValidatorsApp, Zerion)
 - `tests/unit/`: isolated provider and model behavior tests
 - `tests/integration/`: live API integration tests
 - `tests/conftest.py`: shared pytest fixtures and test setup

--- a/main.py
+++ b/main.py
@@ -30,6 +30,7 @@ from providers.rwa import Rwa
 from providers.stakewiz import Stakewiz
 from providers.token_terminal import TokenTerminal
 from providers.validators_app import ValidatorsApp
+from providers.zerion import Zerion
 
 OUTPUT_DIR = Path(__file__).parent / "_output"
 LOOKBACK_DAYS = 7
@@ -45,6 +46,7 @@ PROVIDER_REGISTRY: List[tuple[str, Type[BaseProvider], Optional[str]]] = [
     ("stakewiz", Stakewiz, None),
     ("token_terminal", TokenTerminal, "TOKEN_TERMINAL_API_KEY"),
     ("validators_app", ValidatorsApp, "VALIDATORS_APP_API_TOKEN"),
+    ("zerion", Zerion, "ZERION_API_KEY"),
 ]
 
 

--- a/providers/zerion.py
+++ b/providers/zerion.py
@@ -13,19 +13,7 @@ from providers.base import BaseProvider
 
 
 class Zerion(BaseProvider):
-    """Fetch metrics from the Zerion API.
-
-    The Zerion API is a protocol-decoded portfolio and token-data API covering
-    36+ chains including Solana (base ``https://api.zerion.io/v1``, HTTP Basic
-    auth). This provider currently contributes the daily SOL price to the
-    ``Overview`` category, sourced from Zerion's cross-source price feed.
-
-    Zerion is shipping ecosystem-wide stablecoin data that maps onto this repo's
-    ``Stablecoin`` category (supply, transfer volume, active addresses). Those
-    metrics are intentionally left unwired below until the endpoints are live so
-    the provider stays green in CI — see the notes in ``METRIC_MAP`` and
-    ``get_metric``.
-    """
+    """Fetch SOL price (and, soon, ecosystem stablecoin) metrics from the Zerion API."""
 
     METRIC_MAP: Dict[str, Dict[str, Any]] = {
         "overview_sol_price": {

--- a/providers/zerion.py
+++ b/providers/zerion.py
@@ -13,7 +13,16 @@ from providers.base import BaseProvider
 
 
 class Zerion(BaseProvider):
-    """Fetch SOL price (and, soon, ecosystem stablecoin) metrics from the Zerion API."""
+    """Fetch metrics from the Zerion API.
+
+    Zerion is a protocol-decoded portfolio and token-data API spanning 36+ chains
+    including Solana — portfolio, positions (SPL Token + Token-2022 + native SOL),
+    decoded transactions, token data, and PnL.
+
+    Within this repo it currently contributes SOL price to the Overview category;
+    ecosystem-wide stablecoin metrics (supply, transfer volume, active addresses)
+    follow once those endpoints ship — see the notes in METRIC_MAP and get_metric.
+    """
 
     METRIC_MAP: Dict[str, Dict[str, Any]] = {
         "overview_sol_price": {

--- a/providers/zerion.py
+++ b/providers/zerion.py
@@ -28,19 +28,12 @@ class Zerion(BaseProvider):
         "overview_sol_price": {
             "implementation": "solana",
             "price_chart": True,
-            "methodology": "Daily SOL price in USD from Zerion's cross-source price feed.",
+            "methodology": "Daily SOL price in USD from Zerion's cross-source price feed; covers the trailing 365 days at daily granularity.",
             "methodology_url": "https://docs.zerion.io/api-reference/fungibles/get-a-chart-for-a-fungible-asset-by-implementation",
         },
-        # -- Upcoming: Zerion ecosystem-wide stablecoin metrics ----------------
-        # Zerion is releasing ecosystem-wide stablecoin data that maps directly
-        # onto the Stablecoin metric category already defined in this repo. To
-        # enable when the endpoints ship: add the endpoint config here, add a
-        # parsing branch in fetch_rows(), and uncomment the matching entries in
-        # get_metric()'s stablecoin_metric_map (plus the Stablecoin imports).
-        #
-        # "stablecoin_supply":           -> StablecoinMetricType.SUPPLY
-        # "stablecoin_transfer_volume":  -> StablecoinMetricType.TRANSFER_VOLUME
-        # "stablecoin_active_addresses": -> StablecoinMetricType.ACTIVE_ADDRESSES
+        # TODO: add Zerion ecosystem-wide stablecoin metrics (supply,
+        # transfer_volume, active_addresses) mapping onto the Stablecoin category
+        # once those endpoints ship — see the PR description.
     }
 
     BASE_URL = "https://api.zerion.io/v1"
@@ -77,20 +70,6 @@ class Zerion(BaseProvider):
             .isoformat()
         )
 
-    @staticmethod
-    def _chart_period(start_date: str) -> str:
-        """Pick the smallest day-spaced chart period that still covers start_date.
-
-        Zerion chart periods are fixed windows ending at "now": ``year`` spans
-        the last 365 days at 1-day spacing (ideal for a daily series). For older
-        backfills we fall back to ``max`` (best-effort; spacing widens beyond a
-        year), and downsample to one point per day in fetch_rows().
-        """
-        days_back = (
-            datetime.date.today() - datetime.date.fromisoformat(start_date)
-        ).days
-        return "year" if days_back < 365 else "max"
-
     # -- BaseProvider interface ---------------------------------------------
 
     def fetch_rows(
@@ -103,14 +82,20 @@ class Zerion(BaseProvider):
             raise ValueError(f"Unknown metric '{metric}'. Available: {available}")
 
         if config.get("price_chart"):
-            period = self._chart_period(start_date)
+            # Zerion fungible charts are fixed windows ending "now". `year` is the
+            # trailing 365 days at 1-day spacing — the only period that yields a
+            # true daily series. We deliberately do NOT fall back to `max` for
+            # older ranges: its spacing widens past daily and would silently
+            # return coarse points dressed up as daily values. So history is
+            # capped to the trailing 365 days (documented in the methodology);
+            # dates older than that are simply not returned rather than faked.
             raw = self._get(
-                f"/fungibles/by-implementation/charts/{period}",
+                "/fungibles/by-implementation/charts/year",
                 params={"implementation": config["implementation"], "currency": "usd"},
             )
             points = raw.get("data", {}).get("attributes", {}).get("points", []) or []
-            # Charts return finer-than-daily points for some periods; collapse to
-            # one value per day (last point of each UTC day wins).
+            # `year` is daily already; dedupe defensively so any duplicate UTC day
+            # collapses to its last value.
             daily: Dict[str, float] = {}
             for ts, value in points:
                 row_date = self._ts_to_date(int(ts))
@@ -142,20 +127,7 @@ class Zerion(BaseProvider):
                 value=value,
             )
 
-        # Upcoming stablecoin metrics — enable alongside the METRIC_MAP entries
-        # above (and add: from metrics.stablecoin import Stablecoin,
-        # StablecoinMetricType):
-        #
-        # stablecoin_metric_map = {
-        #     "stablecoin_supply": StablecoinMetricType.SUPPLY,
-        #     "stablecoin_transfer_volume": StablecoinMetricType.TRANSFER_VOLUME,
-        #     "stablecoin_active_addresses": StablecoinMetricType.ACTIVE_ADDRESSES,
-        # }
-        # if metric in stablecoin_metric_map:
-        #     return Stablecoin.from_metric_type(
-        #         metric_type=stablecoin_metric_map[metric],
-        #         date=parsed_date,
-        #         value=value,
-        #     )
+        # TODO: map upcoming stablecoin metrics to Stablecoin.from_metric_type
+        # here when the endpoints ship (see METRIC_MAP and the PR description).
 
         return None

--- a/providers/zerion.py
+++ b/providers/zerion.py
@@ -1,0 +1,164 @@
+"""Zerion data provider."""
+
+from __future__ import annotations
+
+import datetime
+import os
+from typing import Any, Dict, List, Optional
+
+import requests
+
+from metrics.overview import Overview, OverviewMetricType
+from providers.base import BaseProvider
+
+
+class Zerion(BaseProvider):
+    """Fetch metrics from the Zerion API.
+
+    The Zerion API is a protocol-decoded portfolio and token-data API covering
+    36+ chains including Solana (base ``https://api.zerion.io/v1``, HTTP Basic
+    auth). This provider currently contributes the daily SOL price to the
+    ``Overview`` category, sourced from Zerion's cross-source price feed.
+
+    Zerion is shipping ecosystem-wide stablecoin data that maps onto this repo's
+    ``Stablecoin`` category (supply, transfer volume, active addresses). Those
+    metrics are intentionally left unwired below until the endpoints are live so
+    the provider stays green in CI — see the notes in ``METRIC_MAP`` and
+    ``get_metric``.
+    """
+
+    METRIC_MAP: Dict[str, Dict[str, Any]] = {
+        "overview_sol_price": {
+            "implementation": "solana",
+            "price_chart": True,
+            "methodology": "Daily SOL price in USD from Zerion's cross-source price feed.",
+            "methodology_url": "https://docs.zerion.io/api-reference/fungibles/get-a-chart-for-a-fungible-asset-by-implementation",
+        },
+        # -- Upcoming: Zerion ecosystem-wide stablecoin metrics ----------------
+        # Zerion is releasing ecosystem-wide stablecoin data that maps directly
+        # onto the Stablecoin metric category already defined in this repo. To
+        # enable when the endpoints ship: add the endpoint config here, add a
+        # parsing branch in fetch_rows(), and uncomment the matching entries in
+        # get_metric()'s stablecoin_metric_map (plus the Stablecoin imports).
+        #
+        # "stablecoin_supply":           -> StablecoinMetricType.SUPPLY
+        # "stablecoin_transfer_volume":  -> StablecoinMetricType.TRANSFER_VOLUME
+        # "stablecoin_active_addresses": -> StablecoinMetricType.ACTIVE_ADDRESSES
+    }
+
+    BASE_URL = "https://api.zerion.io/v1"
+
+    def __init__(self, *, api_key: Optional[str] = None) -> None:
+        resolved_api_key = api_key or os.environ.get("ZERION_API_KEY") or ""
+        super().__init__(
+            name="Zerion",
+            base_url=self.BASE_URL,
+            api_key=resolved_api_key,
+        )
+        self._session = requests.Session()
+
+    # -- private helpers ----------------------------------------------------
+
+    def _get(self, path: str, *, params: Optional[Dict[str, Any]] = None) -> Any:
+        # Zerion uses HTTP Basic auth: the API key as the username with an empty
+        # password (Authorization: Basic base64("<api_key>:")).
+        resp = self._session.get(
+            f"{self.base_url}{path}",
+            params=params or {},
+            headers={"accept": "application/json"},
+            auth=(self.api_key, ""),
+            timeout=30,
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    @staticmethod
+    def _ts_to_date(ts: int) -> str:
+        return (
+            datetime.datetime.fromtimestamp(ts, tz=datetime.timezone.utc)
+            .date()
+            .isoformat()
+        )
+
+    @staticmethod
+    def _chart_period(start_date: str) -> str:
+        """Pick the smallest day-spaced chart period that still covers start_date.
+
+        Zerion chart periods are fixed windows ending at "now": ``year`` spans
+        the last 365 days at 1-day spacing (ideal for a daily series). For older
+        backfills we fall back to ``max`` (best-effort; spacing widens beyond a
+        year), and downsample to one point per day in fetch_rows().
+        """
+        days_back = (
+            datetime.date.today() - datetime.date.fromisoformat(start_date)
+        ).days
+        return "year" if days_back < 365 else "max"
+
+    # -- BaseProvider interface ---------------------------------------------
+
+    def fetch_rows(
+        self, metric: str, start_date: str, end_date: str, **kwargs: Any
+    ) -> List[Dict[str, Any]]:
+        """Return normalized {"date": str, "value": float} records for the given range (both dates inclusive)."""
+        config = self.METRIC_MAP.get(metric)
+        if config is None:
+            available = ", ".join(self.METRIC_MAP)
+            raise ValueError(f"Unknown metric '{metric}'. Available: {available}")
+
+        if config.get("price_chart"):
+            period = self._chart_period(start_date)
+            raw = self._get(
+                f"/fungibles/by-implementation/charts/{period}",
+                params={"implementation": config["implementation"], "currency": "usd"},
+            )
+            points = raw.get("data", {}).get("attributes", {}).get("points", []) or []
+            # Charts return finer-than-daily points for some periods; collapse to
+            # one value per day (last point of each UTC day wins).
+            daily: Dict[str, float] = {}
+            for ts, value in points:
+                row_date = self._ts_to_date(int(ts))
+                if start_date <= row_date <= end_date:
+                    daily[row_date] = float(value)
+            return [
+                {"date": row_date, "value": daily[row_date]}
+                for row_date in sorted(daily)
+            ]
+
+        raise ValueError(f"Metric '{metric}' is not yet wired to a live endpoint.")
+
+    def get_metric(self, metric: str, date: str, chain: str) -> Overview | None:
+        """Fetch one metric value and return it as a typed metric model."""
+        rows = self.fetch_rows(metric, date, date)
+        if not rows:
+            return None
+
+        value = rows[0]["value"]
+        parsed_date = datetime.date.fromisoformat(date)
+
+        overview_metric_map = {
+            "overview_sol_price": OverviewMetricType.SOL_PRICE,
+        }
+        if metric in overview_metric_map:
+            return Overview.from_metric_type(
+                metric_type=overview_metric_map[metric],
+                date=parsed_date,
+                value=value,
+            )
+
+        # Upcoming stablecoin metrics — enable alongside the METRIC_MAP entries
+        # above (and add: from metrics.stablecoin import Stablecoin,
+        # StablecoinMetricType):
+        #
+        # stablecoin_metric_map = {
+        #     "stablecoin_supply": StablecoinMetricType.SUPPLY,
+        #     "stablecoin_transfer_volume": StablecoinMetricType.TRANSFER_VOLUME,
+        #     "stablecoin_active_addresses": StablecoinMetricType.ACTIVE_ADDRESSES,
+        # }
+        # if metric in stablecoin_metric_map:
+        #     return Stablecoin.from_metric_type(
+        #         metric_type=stablecoin_metric_map[metric],
+        #         date=parsed_date,
+        #         value=value,
+        #     )
+
+        return None

--- a/providers/zerion.py
+++ b/providers/zerion.py
@@ -39,7 +39,9 @@ class Zerion(BaseProvider):
     BASE_URL = "https://api.zerion.io/v1"
 
     def __init__(self, *, api_key: Optional[str] = None) -> None:
-        resolved_api_key = api_key or os.environ.get("ZERION_API_KEY") or ""
+        resolved_api_key = api_key or self._resolve_api_key()
+        if not resolved_api_key:
+            raise ValueError("API key is required")
         super().__init__(
             name="Zerion",
             base_url=self.BASE_URL,
@@ -48,6 +50,10 @@ class Zerion(BaseProvider):
         self._session = requests.Session()
 
     # -- private helpers ----------------------------------------------------
+
+    @staticmethod
+    def _resolve_api_key() -> Optional[str]:
+        return os.environ.get("ZERION_API_KEY")
 
     def _get(self, path: str, *, params: Optional[Dict[str, Any]] = None) -> Any:
         # Zerion uses HTTP Basic auth: the API key as the username with an empty
@@ -97,7 +103,10 @@ class Zerion(BaseProvider):
             # `year` is daily already; dedupe defensively so any duplicate UTC day
             # collapses to its last value.
             daily: Dict[str, float] = {}
-            for ts, value in points:
+            for point in points:
+                if not isinstance(point, (list, tuple)) or len(point) < 2:
+                    continue
+                ts, value = point[0], point[1]
                 row_date = self._ts_to_date(int(ts))
                 if start_date <= row_date <= end_date:
                     daily[row_date] = float(value)
@@ -130,4 +139,6 @@ class Zerion(BaseProvider):
         # TODO: map upcoming stablecoin metrics to Stablecoin.from_metric_type
         # here when the endpoints ship (see METRIC_MAP and the PR description).
 
-        return None
+        # Defensive: fetch_rows() already validates the metric is in METRIC_MAP,
+        # so reaching here means a known metric has no typed-model mapping yet.
+        raise ValueError(f"Metric '{metric}' has no typed-model mapping in get_metric.")

--- a/tests/integration/test_zerion_provider_integration.py
+++ b/tests/integration/test_zerion_provider_integration.py
@@ -1,0 +1,35 @@
+"""Integration tests for the Zerion provider."""
+
+from __future__ import annotations
+
+import datetime
+import os
+
+import pytest
+from dotenv import load_dotenv
+
+from metrics.overview import Overview, OverviewMetricType
+from providers.zerion import Zerion
+
+load_dotenv()
+API_KEY = os.environ.get("ZERION_API_KEY")
+
+
+@pytest.mark.integration
+def test_get_sol_price_live_api() -> None:
+    """Calls the Zerion API directly and validates response mapping."""
+    if not API_KEY:
+        pytest.skip("Set ZERION_API_KEY to run live Zerion integration tests.")
+
+    provider = Zerion(api_key=API_KEY)
+    recent_date = (datetime.date.today() - datetime.timedelta(days=2)).isoformat()
+    metric = provider.get_metric(
+        metric="overview_sol_price",
+        date=recent_date,
+        chain="solana",
+    )
+
+    assert metric is not None
+    assert isinstance(metric, Overview)
+    assert metric.metric_type == OverviewMetricType.SOL_PRICE
+    assert metric.value > 0

--- a/tests/integration/test_zerion_provider_integration.py
+++ b/tests/integration/test_zerion_provider_integration.py
@@ -32,4 +32,5 @@ def test_get_sol_price_live_api() -> None:
     assert metric is not None
     assert isinstance(metric, Overview)
     assert metric.metric_type == OverviewMetricType.SOL_PRICE
-    assert metric.value > 0
+    # Plausibility bound (not just > 0) to catch unit/scaling regressions.
+    assert 10 < metric.value < 10_000

--- a/tests/unit/test_zerion_provider.py
+++ b/tests/unit/test_zerion_provider.py
@@ -27,7 +27,7 @@ def _make_mock_resp(payload):
 
 
 def test_get_sol_price_returns_overview_metric() -> None:
-    provider = Zerion()
+    provider = Zerion(api_key="test-key")
     sentinel_metric = object()
 
     with (
@@ -45,7 +45,7 @@ def test_get_sol_price_returns_overview_metric() -> None:
 
 
 def test_fetch_rows_filters_by_date_range() -> None:
-    provider = Zerion()
+    provider = Zerion(api_key="test-key")
     raw = {
         "data": {
             "attributes": {
@@ -67,7 +67,7 @@ def test_fetch_rows_filters_by_date_range() -> None:
 
 
 def test_fetch_rows_collapses_intraday_points_to_one_per_day() -> None:
-    provider = Zerion()
+    provider = Zerion(api_key="test-key")
     raw = {
         "data": {
             "attributes": {
@@ -86,9 +86,18 @@ def test_fetch_rows_collapses_intraday_points_to_one_per_day() -> None:
 
 
 def test_fetch_rows_raises_on_unknown_metric() -> None:
-    provider = Zerion()
+    provider = Zerion(api_key="test-key")
     try:
         provider.fetch_rows("nonexistent_metric", "2026-01-01", "2026-01-31")
         assert False, "Expected ValueError"
     except ValueError as exc:
         assert "nonexistent_metric" in str(exc)
+
+
+def test_init_requires_api_key(monkeypatch) -> None:
+    monkeypatch.delenv("ZERION_API_KEY", raising=False)
+    try:
+        Zerion()
+        assert False, "Expected ValueError"
+    except ValueError as exc:
+        assert "API key" in str(exc)

--- a/tests/unit/test_zerion_provider.py
+++ b/tests/unit/test_zerion_provider.py
@@ -1,0 +1,94 @@
+"""Unit tests for the Zerion provider."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from metrics.overview import Overview, OverviewMetricType
+from providers.zerion import Zerion
+
+# Zerion chart response: data.attributes.points is a list of [unix_seconds, price].
+_MOCK_RAW = {
+    "data": {
+        "attributes": {
+            "points": [
+                [1767225600, 200.0],  # 2026-01-01
+            ]
+        }
+    }
+}
+
+
+def _make_mock_resp(payload):
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = payload
+    mock_resp.raise_for_status = MagicMock()
+    return mock_resp
+
+
+def test_get_sol_price_returns_overview_metric() -> None:
+    provider = Zerion()
+    sentinel_metric = object()
+
+    with (
+        patch.object(provider._session, "get", return_value=_make_mock_resp(_MOCK_RAW)),
+        patch.object(
+            Overview, "from_metric_type", return_value=sentinel_metric
+        ) as mock_factory,
+    ):
+        result = provider.get_metric("overview_sol_price", "2026-01-01", "solana")
+
+    assert result is sentinel_metric
+    mock_factory.assert_called_once()
+    assert mock_factory.call_args.kwargs["metric_type"] == OverviewMetricType.SOL_PRICE
+    assert mock_factory.call_args.kwargs["value"] == 200.0
+
+
+def test_fetch_rows_filters_by_date_range() -> None:
+    provider = Zerion()
+    raw = {
+        "data": {
+            "attributes": {
+                "points": [
+                    [1704067200, 100.0],  # 2024-01-01
+                    [1767225600, 200.0],  # 2026-01-01
+                    [1798761600, 300.0],  # 2027-01-01
+                ]
+            }
+        }
+    }
+
+    with patch.object(provider._session, "get", return_value=_make_mock_resp(raw)):
+        rows = provider.fetch_rows("overview_sol_price", "2025-01-01", "2026-06-01")
+
+    assert len(rows) == 1
+    assert rows[0]["date"] == "2026-01-01"
+    assert rows[0]["value"] == 200.0
+
+
+def test_fetch_rows_collapses_intraday_points_to_one_per_day() -> None:
+    provider = Zerion()
+    raw = {
+        "data": {
+            "attributes": {
+                "points": [
+                    [1767225600, 200.0],  # 2026-01-01 00:00 UTC
+                    [1767268800, 210.0],  # 2026-01-01 12:00 UTC (later -> wins)
+                ]
+            }
+        }
+    }
+
+    with patch.object(provider._session, "get", return_value=_make_mock_resp(raw)):
+        rows = provider.fetch_rows("overview_sol_price", "2026-01-01", "2026-01-01")
+
+    assert rows == [{"date": "2026-01-01", "value": 210.0}]
+
+
+def test_fetch_rows_raises_on_unknown_metric() -> None:
+    provider = Zerion()
+    try:
+        provider.fetch_rows("nonexistent_metric", "2026-01-01", "2026-01-31")
+        assert False, "Expected ValueError"
+    except ValueError as exc:
+        assert "nonexistent_metric" in str(exc)


### PR DESCRIPTION
## Add a Zerion data provider

This adds [Zerion](https://zerion.io) as a data provider, following the existing `BaseProvider` pattern (modeled closely on `providers/defillama.py`).

### What the Zerion API is
The [Zerion API](https://docs.zerion.io) is a protocol-decoded portfolio and token-data API covering 36+ chains **including Solana**. It returns enriched, USD-priced on-chain data with auth via HTTP Basic (`base64("<API_KEY>:")`); base URL `https://api.zerion.io/v1`. Free keys at [dashboard.zerion.io](https://dashboard.zerion.io).

### What Zerion exposes for Solana
- **Portfolio** — `GET /wallets/{address}/portfolio` — aggregated USD value across all chains, including Solana.
- **Positions** — `GET /wallets/{address}/positions` — SPL token balances (Token + Token-2022 programs) and native SOL, with USD valuations.
- **Transactions** — `GET /wallets/{address}/transactions` — full Solana history with decoded transfers and intent.
- **Token data** — `GET /fungibles/{chain:address}` — metadata, 24h volume, liquidity, and price history.
- **PnL** — `GET /wallets/{address}/pnl` — SOL/stablecoin pairs (phased rollout, ~4-month depth).

Solana positions are served as **real-time live reads directly from Solana RPC** (not cached), so balances reflect on-chain state immediately.

Other relevant endpoint groups: swap & bridge (`/swap/quotes/`), chains/dApps/gas (`/chains/`, `/dapps/`, `/gas-prices/`), and webhooks (`/tx-subscriptions/`).

### What this PR wires up today
Zerion is a wallet/token-level API, so the clean fit with this repo's network-level metrics is **SOL price**:

- `overview_sol_price` → `OverviewMetricType.SOL_PRICE`, from `GET /v1/fungibles/by-implementation/charts/year` with `implementation=solana` (chain-only returns the native base asset). Points are collapsed to one value per UTC day and filtered to the requested range.

> **Note — DefiLlama already provides `overview_sol_price`.** This is intentional: Zerion's value here is an **independent cross-source price feed** (useful as a redundancy/cross-check against the existing source), and the **real differentiator is the upcoming ecosystem stablecoin metrics** below — that's where Zerion adds data this pipeline doesn't have today. The aggregator writes one file per provider, so there's no key clash.

Registered in `main.py` as `("zerion", Zerion, "ZERION_API_KEY")` — skipped automatically when the key isn't set, like the other providers.

**History limit:** Zerion's fungible charts are fixed windows ending "now", so this provider covers the **trailing 365 days at daily granularity** (the `year` period). It deliberately does *not* fall back to `max` for older ranges — `max` widens past daily spacing and would silently return coarse points dressed up as daily values. Dates older than 365 days are simply not returned rather than faked; this is documented in the metric's methodology string.

### Coming next: ecosystem-wide stablecoin metrics
Zerion is shipping ecosystem-wide stablecoin data that maps directly onto this repo's existing `Stablecoin` category (`supply`, `transfer_volume`, `active_addresses`). The provider leaves a `TODO` in `METRIC_MAP` / `get_metric` for the drop-in; the metrics are intentionally unwired until the endpoints are live so CI stays green. Happy to follow up with a second PR once they ship. (Token-level price/volume/liquidity-by-mint is also a strong Zerion fit but needs a new `metrics/token.py` model — better as a separate issue.)

### Repo housekeeping
Added a `.env.example` — the README's Quick Start says `cp .env.example .env`, but the file wasn't in the repo. It now lists all provider env vars (the existing 9 + `ZERION_API_KEY`). Happy to drop this if you maintain it elsewhere.

### Tests
- `tests/unit/test_zerion_provider.py` — mocked: SOL price → `Overview`, date-range filtering, intraday→daily collapse, unknown-metric error.
- `tests/integration/test_zerion_provider_integration.py` — live SOL price returns an `Overview` within a plausibility bound (`10 < value < 10000`); skips without `ZERION_API_KEY`.

Verified locally: `make lint` clean (ruff + black), `make test` green, and `python main.py --providers zerion` produces a clean daily SOL-price series.

### Note on credentials
No API key is included in this PR — the provider reads `ZERION_API_KEY` from the environment (`.env`, gitignored). I'll share a key with the team separately to wire it into your pipeline/UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
