### PR TITLE
Add DexPaprika provider for Solana DEX metrics

### DIFF
--- a/main.py
+++ b/main.py
@@ -25,6 +25,7 @@ from providers.artemis import Artemis
 from providers.base import BaseProvider
 from providers.blockworks import Blockworks
 from providers.defillama import DefiLlama
+from providers.dexpaprika import DexPaprika
 from providers.dune import Dune
 from providers.rwa import Rwa
 from providers.stakewiz import Stakewiz
@@ -40,6 +41,7 @@ PROVIDER_REGISTRY: List[tuple[str, Type[BaseProvider], Optional[str]]] = [
     ("artemis", Artemis, "ARTEMIS_API_KEY"),
     ("blockworks", Blockworks, "BLOCKWORKS_API_KEY"),
     ("defillama", DefiLlama, "DEFILLAMA_API_KEY"),
+    ("dexpaprika", DexPaprika, None),
     ("dune", Dune, "DUNE_API_KEY"),
     ("rwa", Rwa, "RWA_API_KEY"),
     ("stakewiz", Stakewiz, None),

--- a/providers/dexpaprika.py
+++ b/providers/dexpaprika.py
@@ -138,7 +138,7 @@ class DexPaprika(BaseProvider):
             return None
         return self._to_float(summary.get(field))
 
-    def _active_dex_count(self, endpoint: str) -> int:
+    def _active_dex_count(self, endpoint: str) -> Optional[int]:
         """Count DEXes on the chain with non-zero 24h volume.
 
         ``/networks/<chain>/dexes`` lists DEX *protocols* (Solana has ~9:
@@ -148,9 +148,15 @@ class DexPaprika(BaseProvider):
         page and the count can no longer be trusted, so we raise rather than
         under-report. (The endpoint's ``page`` param is a server-side no-op
         today, so true pagination isn't available to walk.)
+
+        Returns ``None`` when the response has no ``dexes`` list (malformed or
+        schema-changed), so the caller skips the row instead of recording a
+        misleading ``0``. Mirrors ``_network_field`` / ``_token_summary_field``.
         """
         payload = self._get(endpoint, params={"limit": self._DEX_PAGE_LIMIT})
-        dexes = payload.get("dexes", []) if isinstance(payload, dict) else []
+        dexes = payload.get("dexes") if isinstance(payload, dict) else None
+        if not isinstance(dexes, list):
+            return None
         if len(dexes) >= self._DEX_PAGE_LIMIT:
             raise RuntimeError(
                 f"DEX list hit the page limit ({self._DEX_PAGE_LIMIT}); "
@@ -183,7 +189,8 @@ class DexPaprika(BaseProvider):
             return []
 
         if config.get("count_active_dexes"):
-            value: Optional[float] = float(self._active_dex_count(config["endpoint"]))
+            count = self._active_dex_count(config["endpoint"])
+            value: Optional[float] = None if count is None else float(count)
         elif "summary_field" in config:
             value = self._token_summary_field(
                 config["endpoint"], config["summary_field"]

--- a/providers/dexpaprika.py
+++ b/providers/dexpaprika.py
@@ -1,0 +1,219 @@
+"""DexPaprika data provider."""
+
+from __future__ import annotations
+
+import datetime
+import math
+from typing import Any, Dict, List, Optional
+
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+from metrics.defi import Defi, DefiMetricType
+from metrics.overview import Overview, OverviewMetricType
+from providers.base import BaseProvider
+
+
+class DexPaprika(BaseProvider):
+    """Fetch Solana DeFi (DEX) metrics from the DexPaprika public API.
+
+    Endpoints
+    ---------
+    - Networks:      /networks               (per-chain 24h aggregates: volume, transactions)
+    - Network DEXes: /networks/solana/dexes  (per-DEX 24h aggregates; used to count active DEXes)
+    - Token latest:  /networks/solana/tokens/<mint>  (per-token summary; used for SOL price)
+
+    All exposed metrics are current snapshots rather than historical series,
+    so ``fetch_rows`` returns a single row dated today when today falls within the
+    requested range (consistent with the aggregator's other snapshot providers).
+
+    The session retries idempotent GETs with capped exponential backoff + jitter
+    and honors ``Retry-After`` on 429/5xx, because the public API is rate-limited.
+
+    No API key required (public REST API).
+    """
+
+    _CHAIN = "solana"
+    BASE_URL = "https://api.dexpaprika.com"
+    # Wrapped SOL mint. DexPaprika prices native SOL via the wSOL token.
+    _WSOL_MINT = "So11111111111111111111111111111111111111112"
+
+    # (connect, read) timeouts; requests has no default and would otherwise hang.
+    _TIMEOUT = (5, 30)
+    _DEX_PAGE_LIMIT = 100
+
+    METRIC_MAP: Dict[str, Dict[str, Any]] = {
+        "defi_dex_volume": {
+            "endpoint": "/networks",
+            "network_field": "volume_usd_24h",
+            "methodology": "Aggregate 24h USD spot trading volume across all DEXes indexed on Solana.",
+            "methodology_url": "https://docs.dexpaprika.com/api-reference/networks/get-a-list-of-available-blockchain-networks",
+        },
+        "defi_dex_transactions": {
+            "endpoint": "/networks",
+            "network_field": "txns_24h",
+            "methodology": "Aggregate 24h DEX transaction count (swaps and liquidity events) across Solana.",
+            "methodology_url": "https://docs.dexpaprika.com/api-reference/networks/get-a-list-of-available-blockchain-networks",
+        },
+        "defi_dex_count": {
+            "endpoint": "/networks/solana/dexes",
+            "count_active_dexes": True,
+            "methodology": "Number of DEXes indexed on Solana with non-zero 24h trading volume.",
+            "methodology_url": "https://docs.dexpaprika.com/api-reference/dexes/get-a-list-of-available-dexes-on-a-network",
+        },
+        "overview_sol_price": {
+            "endpoint": f"/networks/solana/tokens/{_WSOL_MINT}",
+            "summary_field": "price_usd",
+            "methodology": "Spot USD price of SOL (wrapped SOL), volume-weighted across Solana DEX pools.",
+            "methodology_url": "https://docs.dexpaprika.com/api-reference/tokens/get-a-tokens-latest-data-on-a-network",
+        },
+    }
+
+    _DEFI_METRIC_TYPE_MAP: Dict[str, DefiMetricType] = {
+        "defi_dex_volume": DefiMetricType.DEX_VOLUME,
+        "defi_dex_transactions": DefiMetricType.DEX_TRANSACTIONS,
+        "defi_dex_count": DefiMetricType.DEX_COUNT,
+    }
+
+    _OVERVIEW_METRIC_TYPE_MAP: Dict[str, OverviewMetricType] = {
+        "overview_sol_price": OverviewMetricType.SOL_PRICE,
+    }
+
+    def __init__(self) -> None:
+        super().__init__(
+            name="DexPaprika",
+            base_url=self.BASE_URL,
+            api_key="",
+        )
+        self._session = requests.Session()
+        retry = Retry(
+            total=3,
+            backoff_factor=0.5,
+            backoff_jitter=0.5,
+            status_forcelist=(408, 429, 500, 502, 503, 504),
+            allowed_methods=frozenset({"GET"}),
+            respect_retry_after_header=True,
+            raise_on_status=False,
+        )
+        adapter = HTTPAdapter(max_retries=retry)
+        self._session.mount("https://", adapter)
+
+    # -- private helpers ----------------------------------------------------
+
+    @staticmethod
+    def _to_float(value: Any) -> Optional[float]:
+        """Coerce an API value to a finite float, or None if it can't be.
+
+        Guards against schema drift: a field arriving as a string, object, or
+        NaN/Inf yields None (treated as "missing") instead of raising or
+        silently poisoning a metric with a non-finite value.
+        """
+        try:
+            result = float(value)
+        except (TypeError, ValueError):
+            return None
+        return result if math.isfinite(result) else None
+
+    def _get(self, endpoint: str, *, params: Optional[Dict[str, Any]] = None) -> Any:
+        resp = self._session.get(
+            f"{self.base_url}{endpoint}", params=params or {}, timeout=self._TIMEOUT
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    def _network_field(self, field: str) -> Optional[float]:
+        """Return a 24h aggregate field for the target chain from /networks."""
+        networks = self._get("/networks")
+        for network in networks if isinstance(networks, list) else []:
+            if network.get("id") == self._CHAIN:
+                return self._to_float(network.get(field))
+        return None
+
+    def _token_summary_field(self, endpoint: str, field: str) -> Optional[float]:
+        """Return a numeric field from a token's ``summary`` block."""
+        payload = self._get(endpoint)
+        summary = payload.get("summary") if isinstance(payload, dict) else None
+        if not isinstance(summary, dict):
+            return None
+        return self._to_float(summary.get(field))
+
+    def _active_dex_count(self, endpoint: str) -> int:
+        """Count DEXes on the chain with non-zero 24h volume.
+
+        ``/networks/<chain>/dexes`` lists DEX *protocols* (Solana has ~9:
+        raydium, orca, meteora, pumpfun, ...), not pools, so the full set fits
+        in one page. We request ``_DEX_PAGE_LIMIT`` and refuse to silently cap:
+        if a completely full page comes back the protocol set has outgrown one
+        page and the count can no longer be trusted, so we raise rather than
+        under-report. (The endpoint's ``page`` param is a server-side no-op
+        today, so true pagination isn't available to walk.)
+        """
+        payload = self._get(endpoint, params={"limit": self._DEX_PAGE_LIMIT})
+        dexes = payload.get("dexes", []) if isinstance(payload, dict) else []
+        if len(dexes) >= self._DEX_PAGE_LIMIT:
+            raise RuntimeError(
+                f"DEX list hit the page limit ({self._DEX_PAGE_LIMIT}); "
+                "count may be truncated and is no longer reliable."
+            )
+        count = 0
+        for dex in dexes:
+            volume = self._to_float(dex.get("volume_usd_24h"))
+            if volume is not None and volume > 0:
+                count += 1
+        return count
+
+    # -- BaseProvider interface ---------------------------------------------
+
+    def fetch_rows(
+        self, metric: str, start_date: str, end_date: str, **kwargs: Any
+    ) -> List[Dict[str, Any]]:
+        """Return normalized {"date": str, "value": float} records for the given range (both dates inclusive).
+
+        Note: DexPaprika exposes current 24h aggregates, not historical series, so
+        this returns a single row dated today when today falls within the range.
+        """
+        config = self.METRIC_MAP.get(metric)
+        if config is None:
+            available = ", ".join(self.METRIC_MAP)
+            raise ValueError(f"Unknown metric '{metric}'. Available: {available}")
+
+        today = datetime.date.today().isoformat()
+        if not (start_date <= today <= end_date):
+            return []
+
+        if config.get("count_active_dexes"):
+            value: Optional[float] = float(self._active_dex_count(config["endpoint"]))
+        elif "summary_field" in config:
+            value = self._token_summary_field(
+                config["endpoint"], config["summary_field"]
+            )
+        else:
+            value = self._network_field(config["network_field"])
+
+        if value is None:
+            return []
+        return [{"date": today, "value": value}]
+
+    def get_metric(self, metric: str, date: str, chain: str) -> Defi | Overview | None:
+        """Fetch one metric for one date and return it as a typed metric model."""
+        rows = self.fetch_rows(metric, date, date)
+        if not rows:
+            return None
+
+        parsed_date = datetime.date.fromisoformat(date)
+        value = rows[0]["value"]
+
+        defi_type = self._DEFI_METRIC_TYPE_MAP.get(metric)
+        if defi_type is not None:
+            return Defi.from_metric_type(
+                metric_type=defi_type, date=parsed_date, value=value
+            )
+
+        overview_type = self._OVERVIEW_METRIC_TYPE_MAP.get(metric)
+        if overview_type is not None:
+            return Overview.from_metric_type(
+                metric_type=overview_type, date=parsed_date, value=value
+            )
+
+        return None

--- a/tests/integration/test_dexpaprika_provider_integration.py
+++ b/tests/integration/test_dexpaprika_provider_integration.py
@@ -1,0 +1,78 @@
+"""Integration tests for the DexPaprika provider."""
+
+from __future__ import annotations
+
+import datetime
+
+import pytest
+
+from metrics.defi import Defi, DefiMetricType
+from metrics.overview import Overview, OverviewMetricType
+from providers.dexpaprika import DexPaprika
+
+_TODAY = datetime.date.today().isoformat()
+
+
+@pytest.mark.integration
+def test_get_dex_volume_live_api() -> None:
+    """Calls the DexPaprika public API directly and validates response mapping."""
+    provider = DexPaprika()
+    metric = provider.get_metric(
+        metric="defi_dex_volume",
+        date=_TODAY,
+        chain="solana",
+    )
+
+    assert metric is not None
+    assert isinstance(metric, Defi)
+    assert metric.metric_type == DefiMetricType.DEX_VOLUME
+    assert metric.value > 0
+
+
+@pytest.mark.integration
+def test_get_dex_transactions_live_api() -> None:
+    """Confirms the txns_24h response key exists and maps end-to-end."""
+    provider = DexPaprika()
+    metric = provider.get_metric(
+        metric="defi_dex_transactions",
+        date=_TODAY,
+        chain="solana",
+    )
+
+    assert metric is not None
+    assert isinstance(metric, Defi)
+    assert metric.metric_type == DefiMetricType.DEX_TRANSACTIONS
+    assert metric.value > 0
+
+
+@pytest.mark.integration
+def test_get_dex_count_live_api() -> None:
+    """DEX count for Solana should be a positive whole number."""
+    provider = DexPaprika()
+    metric = provider.get_metric(
+        metric="defi_dex_count",
+        date=_TODAY,
+        chain="solana",
+    )
+
+    assert metric is not None
+    assert isinstance(metric, Defi)
+    assert metric.metric_type == DefiMetricType.DEX_COUNT
+    assert metric.value >= 1
+    assert metric.value == int(metric.value)
+
+
+@pytest.mark.integration
+def test_get_sol_price_live_api() -> None:
+    """SOL price for Solana should be a positive USD value."""
+    provider = DexPaprika()
+    metric = provider.get_metric(
+        metric="overview_sol_price",
+        date=_TODAY,
+        chain="solana",
+    )
+
+    assert metric is not None
+    assert isinstance(metric, Overview)
+    assert metric.metric_type == OverviewMetricType.SOL_PRICE
+    assert metric.value > 0

--- a/tests/unit/test_dexpaprika_provider.py
+++ b/tests/unit/test_dexpaprika_provider.py
@@ -172,3 +172,15 @@ def test_get_metric_returns_none_when_no_rows() -> None:
     provider = DexPaprika()
     # Past range -> fetch_rows returns [] -> get_metric returns None.
     assert provider.get_metric("defi_dex_volume", "2024-01-01", "solana") is None
+
+
+def test_get_metric_returns_none_for_mapped_but_untyped_metric() -> None:
+    # Defensive path: a metric present in METRIC_MAP but absent from both type
+    # maps degrades to None instead of raising, even when fetch_rows returns data.
+    provider = DexPaprika()
+    fake = {"endpoint": "/networks", "network_field": "volume_usd_24h"}
+    with patch.dict(DexPaprika.METRIC_MAP, {"unmapped_metric": fake}, clear=False):
+        with patch.object(
+            provider._session, "get", return_value=_make_mock_resp(_NETWORKS_RAW)
+        ):
+            assert provider.get_metric("unmapped_metric", _TODAY, "solana") is None

--- a/tests/unit/test_dexpaprika_provider.py
+++ b/tests/unit/test_dexpaprika_provider.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import datetime
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from metrics.defi import Defi, DefiMetricType
 from metrics.overview import Overview, OverviewMetricType
 from providers.dexpaprika import DexPaprika
@@ -100,11 +102,17 @@ def test_dex_count_raises_if_page_is_full() -> None:
     with patch.object(
         provider._session, "get", return_value=_make_mock_resp(full_page)
     ):
-        try:
+        with pytest.raises(RuntimeError, match="page limit"):
             provider.fetch_rows("defi_dex_count", _TODAY, _TODAY)
-            assert False, "Expected RuntimeError on a full page"
-        except RuntimeError as exc:
-            assert "page limit" in str(exc)
+
+
+def test_dex_count_empty_when_dexes_key_absent() -> None:
+    # A 200 whose body lacks "dexes" (schema drift) must skip the row, not
+    # record a misleading 0. Mirrors the missing-field handling for other metrics.
+    provider = DexPaprika()
+    no_dexes = {"page_info": {"limit": 100, "page": 1}}  # no "dexes" key
+    with patch.object(provider._session, "get", return_value=_make_mock_resp(no_dexes)):
+        assert provider.fetch_rows("defi_dex_count", _TODAY, _TODAY) == []
 
 
 def test_fetch_rows_empty_when_chain_absent() -> None:
@@ -156,11 +164,8 @@ def test_fetch_rows_returns_empty_when_today_out_of_range() -> None:
 
 def test_fetch_rows_raises_on_unknown_metric() -> None:
     provider = DexPaprika()
-    try:
+    with pytest.raises(ValueError, match="nonexistent_metric"):
         provider.fetch_rows("nonexistent_metric", _TODAY, _TODAY)
-        assert False, "Expected ValueError"
-    except ValueError as exc:
-        assert "nonexistent_metric" in str(exc)
 
 
 def test_get_metric_returns_none_when_no_rows() -> None:

--- a/tests/unit/test_dexpaprika_provider.py
+++ b/tests/unit/test_dexpaprika_provider.py
@@ -1,0 +1,169 @@
+"""Unit tests for the DexPaprika provider."""
+
+from __future__ import annotations
+
+import datetime
+from unittest.mock import MagicMock, patch
+
+from metrics.defi import Defi, DefiMetricType
+from metrics.overview import Overview, OverviewMetricType
+from providers.dexpaprika import DexPaprika
+
+_TODAY = datetime.date.today().isoformat()
+
+_NETWORKS_RAW = [
+    {"id": "ethereum", "volume_usd_24h": 1_000_000.0, "txns_24h": 50_000},
+    {"id": "solana", "volume_usd_24h": 5_000_000_000.0, "txns_24h": 28_000_000},
+]
+
+_DEXES_RAW = {
+    "dexes": [
+        {"dex_id": "manifest", "volume_usd_24h": 214_000_000.0},
+        {"dex_id": "orca", "volume_usd_24h": 90_000_000.0},
+        {"dex_id": "dead-dex", "volume_usd_24h": 0},
+    ],
+    "page_info": {"limit": 100, "page": 1},
+}
+
+_SOL_TOKEN_RAW = {
+    "id": "So11111111111111111111111111111111111111112",
+    "name": "Wrapped SOL",
+    "summary": {"price_usd": 68.42, "liquidity_usd": 1_200_000_000.0},
+}
+
+
+def _make_mock_resp(payload):
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = payload
+    mock_resp.raise_for_status = MagicMock()
+    return mock_resp
+
+
+def test_get_dex_volume_returns_defi_metric() -> None:
+    provider = DexPaprika()
+
+    with patch.object(
+        provider._session, "get", return_value=_make_mock_resp(_NETWORKS_RAW)
+    ):
+        result = provider.get_metric("defi_dex_volume", _TODAY, "solana")
+
+    # Build a real model (no factory mock) so a swapped metadata mapping or a
+    # broken Defi/Overview branch would actually fail here.
+    assert isinstance(result, Defi)
+    assert result.metric_type == DefiMetricType.DEX_VOLUME
+    assert result.value == 5_000_000_000.0
+
+
+def test_fetch_rows_dex_transactions_picks_solana() -> None:
+    provider = DexPaprika()
+    with patch.object(
+        provider._session, "get", return_value=_make_mock_resp(_NETWORKS_RAW)
+    ):
+        rows = provider.fetch_rows("defi_dex_transactions", _TODAY, _TODAY)
+
+    assert rows == [{"date": _TODAY, "value": 28_000_000.0}]
+
+
+def test_fetch_rows_dex_count_counts_only_active() -> None:
+    provider = DexPaprika()
+    with patch.object(
+        provider._session, "get", return_value=_make_mock_resp(_DEXES_RAW)
+    ):
+        rows = provider.fetch_rows("defi_dex_count", _TODAY, _TODAY)
+
+    # 2 of 3 DEXes have non-zero 24h volume
+    assert rows == [{"date": _TODAY, "value": 2.0}]
+
+
+def test_dex_count_ignores_string_typed_volume() -> None:
+    # A volume that arrives as a non-numeric string must not be miscounted as active.
+    provider = DexPaprika()
+    payload = {
+        "dexes": [
+            {"dex_id": "real", "volume_usd_24h": 5.0},
+            {"dex_id": "weird", "volume_usd_24h": "N/A"},
+        ]
+    }
+    with patch.object(provider._session, "get", return_value=_make_mock_resp(payload)):
+        rows = provider.fetch_rows("defi_dex_count", _TODAY, _TODAY)
+
+    assert rows == [{"date": _TODAY, "value": 1.0}]
+
+
+def test_dex_count_raises_if_page_is_full() -> None:
+    # A completely full page means the protocol set outgrew one page; refuse to
+    # silently under-report rather than capping the count.
+    provider = DexPaprika()
+    full_page = {
+        "dexes": [{"dex_id": f"d{i}", "volume_usd_24h": 1.0} for i in range(100)]
+    }
+    with patch.object(
+        provider._session, "get", return_value=_make_mock_resp(full_page)
+    ):
+        try:
+            provider.fetch_rows("defi_dex_count", _TODAY, _TODAY)
+            assert False, "Expected RuntimeError on a full page"
+        except RuntimeError as exc:
+            assert "page limit" in str(exc)
+
+
+def test_fetch_rows_empty_when_chain_absent() -> None:
+    provider = DexPaprika()
+    only_eth = [{"id": "ethereum", "volume_usd_24h": 1.0, "txns_24h": 1}]
+    with patch.object(provider._session, "get", return_value=_make_mock_resp(only_eth)):
+        assert provider.fetch_rows("defi_dex_volume", _TODAY, _TODAY) == []
+
+
+def test_fetch_rows_empty_when_field_is_null() -> None:
+    provider = DexPaprika()
+    null_field = [{"id": "solana", "volume_usd_24h": None, "txns_24h": 1}]
+    with patch.object(
+        provider._session, "get", return_value=_make_mock_resp(null_field)
+    ):
+        assert provider.fetch_rows("defi_dex_volume", _TODAY, _TODAY) == []
+
+
+def test_fetch_rows_empty_when_token_summary_missing() -> None:
+    provider = DexPaprika()
+    no_summary = {"id": "So111", "name": "Wrapped SOL"}  # no "summary" block
+    with patch.object(
+        provider._session, "get", return_value=_make_mock_resp(no_summary)
+    ):
+        assert provider.fetch_rows("overview_sol_price", _TODAY, _TODAY) == []
+
+
+def test_get_sol_price_returns_overview_metric() -> None:
+    provider = DexPaprika()
+
+    with patch.object(
+        provider._session, "get", return_value=_make_mock_resp(_SOL_TOKEN_RAW)
+    ):
+        result = provider.get_metric("overview_sol_price", _TODAY, "solana")
+
+    # Real Overview model: proves the overview branch routes correctly and the
+    # SOL_PRICE metadata is wired up.
+    assert isinstance(result, Overview)
+    assert result.metric_type == OverviewMetricType.SOL_PRICE
+    assert result.value == 68.42
+
+
+def test_fetch_rows_returns_empty_when_today_out_of_range() -> None:
+    provider = DexPaprika()
+    # No HTTP call should be needed; range is entirely in the past.
+    rows = provider.fetch_rows("defi_dex_volume", "2024-01-01", "2024-01-02")
+    assert rows == []
+
+
+def test_fetch_rows_raises_on_unknown_metric() -> None:
+    provider = DexPaprika()
+    try:
+        provider.fetch_rows("nonexistent_metric", _TODAY, _TODAY)
+        assert False, "Expected ValueError"
+    except ValueError as exc:
+        assert "nonexistent_metric" in str(exc)
+
+
+def test_get_metric_returns_none_when_no_rows() -> None:
+    provider = DexPaprika()
+    # Past range -> fetch_rows returns [] -> get_metric returns None.
+    assert provider.get_metric("defi_dex_volume", "2024-01-01", "solana") is None


### PR DESCRIPTION
## Add a DexPaprika provider

This adds [DexPaprika](https://dexpaprika.com) as a data provider, following the existing `BaseProvider` pattern (keyless, modeled on `providers/stakewiz.py`; metric mapping modeled on `providers/defillama.py`).

### What the DexPaprika API is

The [DexPaprika API](https://docs.dexpaprika.com) is a public DEX data API covering 30+ chains **including Solana**, indexing all major DEX protocols with USD-priced volume, transactions, liquidity, and token data. Base URL `https://api.dexpaprika.com`. No API key, no auth, no rate-limit signup.

### What this PR wires up today

DexPaprika is a DEX-level market-data API, so the clean fit with this repo's metrics is Solana DEX activity and SOL price:

| Metric | Maps to | Source |
|---|---|---|
| `defi_dex_volume` | `DefiMetricType.DEX_VOLUME` | `/networks` -> `volume_usd_24h` |
| `defi_dex_transactions` | `DefiMetricType.DEX_TRANSACTIONS` | `/networks` -> `txns_24h` |
| `defi_dex_count` | `DefiMetricType.DEX_COUNT` | `/networks/solana/dexes` |
| `overview_sol_price` | `OverviewMetricType.SOL_PRICE` | `/networks/solana/tokens/{wSOL}` -> `summary.price_usd` |

> **Note: several providers already supply `defi_dex_volume` and `overview_sol_price`.** This is intentional: DexPaprika is an **independent DEX aggregator**, so its value here is a methodologically distinct cross-source on the most-sourced metrics, plus a keyless one (no API key to provision or maintain). The aggregator writes one file per provider, so there is no key clash.

Registered in `main.py` as `("dexpaprika", DexPaprika, None)`, no env var, so it always runs, like `stakewiz`.

**Snapshot source:** DexPaprika exposes current 24h aggregates, not historical series, so `fetch_rows` returns one row dated today when today falls in the requested range. Same behavior as the other snapshot providers. Dates outside today are not returned rather than backfilled with a repeated value.

**Resilience:** idempotent GETs retry with capped exponential backoff and jitter and honor `Retry-After` on 429 and 5xx. Explicit connect and read timeouts. Missing or non-finite fields parse to a clean "missing" rather than raising. `defi_dex_count` reflects DEX protocols (about nine on Solana today), not pools, and raises rather than silently capping if the set ever outgrows one page.

### Scope

This provider implements only what DexPaprika can source directly. It does not implement `defi_dex_traders` (the API has no unique-trader endpoint) or metrics outside DEX market data (L1/consensus, stablecoin on-chain flows, staking and validators), since a derived value there would not be a true equivalent.

### Notes for reviewers

1. `defi_dex_volume` and `defi_dex_transactions` are rolling 24h. Some providers report calendar UTC-day values. The methodology strings state "24h"; you may want the window normalized for strict comparability.
2. `overview_sol_price` is a spot price, while the `SOL_PRICE` metadata describes a daily average. Fine for a daily snapshot run, noting the wording.

### Tests

- `tests/unit/test_dexpaprika_provider.py`: mocked. Each metric maps to its model, date-range filtering, active-DEX counting, the non-finite/string guards, the full-page guard, unknown-metric error.
- `tests/integration/test_dexpaprika_provider_integration.py`: live. Volume, transactions, count, and SOL price each return the right model with plausible values. Keyless, so no skip.

Verified locally: `make lint` clean (ruff + black), `make test` green, and `python main.py --providers dexpaprika` produces a clean snapshot for all four metrics.
