### PR TITLE
Simplify stablecoin supply query to use total_supply_usd

### DIFF
--- a/providers/allium.py
+++ b/providers/allium.py
@@ -26,11 +26,8 @@ class Allium(BaseProvider):
             "sql": """
                 SELECT
                     date,
-                    SUM(circulating_supply * price) AS usd
-                FROM solana.stablecoins.supply_distribution_daily t1
-                LEFT JOIN solana.prices.token_prices_hourly t2
-                    ON t1.date = t2.timestamp
-                    AND t1.token_address = t2.token_mint
+                    SUM(total_supply_usd) AS usd
+                FROM solana.stablecoins.supply_distribution_daily
                 WHERE date >= DATE '{start_date}'
                   AND date < DATEADD('day', 1, DATE '{end_date}')
                 GROUP BY ALL


### PR DESCRIPTION
## Problem
The `stablecoin_supply` query in `providers/allium.py` joined `solana.stablecoins.supply_distribution_daily` to `solana.prices.token_prices_hourly` and computed `SUM(circulating_supply * price)` to get supply in USD.

## Fix
`supply_distribution_daily` already exposes a precomputed `total_supply_usd` column, so the price join is unnecessary. Sum that column directly instead.

```sql
SELECT
    date,
    SUM(total_supply_usd) AS usd
FROM solana.stablecoins.supply_distribution_daily
WHERE date >= DATE '{start_date}'
  AND date < DATEADD('day', 1, DATE '{end_date}')
GROUP BY ALL
ORDER BY date
```

## Scope
Single-metric SQL change; date filter, `GROUP BY ALL`, and `ORDER BY` are unchanged. No code paths added or removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)