### PR TITLE
Fix Time range to avoid duplication date

### DIFF
--- a/providers/defillama.py
+++ b/providers/defillama.py
@@ -110,7 +110,7 @@ class DefiLlama(BaseProvider):
         if config.get("coins_chart"):
             start_ts = int(
                 datetime.datetime.fromisoformat(start_date)
-                .replace(tzinfo=datetime.timezone.utc)
+                .replace(hour=12, tzinfo=datetime.timezone.utc)
                 .timestamp()
             )
             span = min(
@@ -118,7 +118,7 @@ class DefiLlama(BaseProvider):
                     datetime.date.fromisoformat(end_date)
                     - datetime.date.fromisoformat(start_date)
                 ).days
-                + 1,
+                + 2,
                 365,
             )
             raw = self._get(


### PR DESCRIPTION
## Issue 

<img width="989" height="328" alt="Screenshot from 2026-07-09 12-26-10" src="https://github.com/user-attachments/assets/1542e57a-43f5-4999-9fdd-fd9694df15a2" />


## Updates
- Anchored `start_ts` to noon UTC (was midnight) and bumped `span` by one extra day.
  DefiLlama's coins/chart endpoint snaps each daily point to a timestamp that
  jitters by ~±15s. With a midnight-UTC start, points sit only seconds from
  the day boundary, so that jitter randomly flips which calendar day a point
  is attributed to — causing skipped dates (e.g. missing days) and duplicate
  dates in the output. Noon UTC gives a ~12-hour margin so jitter can no
  longer cross a day boundary.

