### PR TITLE
Include bridged supply in Token Terminal stablecoin metric

### DIFF
--- a/providers/token_terminal.py
+++ b/providers/token_terminal.py
@@ -125,6 +125,11 @@ class TokenTerminal(BaseProvider):
             row_date = str(row.get(config["date_field"], ""))[:10]
             if not row_date or not (start_date <= row_date <= end_date):
                 continue
+            # Sum the values that are present for this day. If one series has no
+            # value for a date (e.g. bridged supply on dates before any bridged
+            # stablecoins existed on the chain), the absent series is treated as
+            # zero and the day still reports the available total. Only days with
+            # no values at all for any requested metric are dropped.
             present = [row.get(field) for field in value_fields]
             present = [v for v in present if v is not None]
             if not present:

--- a/providers/token_terminal.py
+++ b/providers/token_terminal.py
@@ -39,10 +39,21 @@ class TokenTerminal(BaseProvider):
             "value_field": "active_addresses_daily",
         },
         "stablecoin_supply": {
-            "metric_id": "ecosystem_stablecoin_supply",
+            # Total stablecoin supply = native issuance + bridged-in supply.
+            # Token Terminal exposes these as two separate metric_ids; requesting
+            # both in one call and summing them yields the bridged-inclusive total.
+            "metric_id": "ecosystem_stablecoin_supply,ecosystem_bridged_stablecoin_supply",
             "date_field": "timestamp",
-            "value_field": "ecosystem_stablecoin_supply",
-            "methodology": "Circulating supply excludes issuer treasury and pre-minted, not-yet-issued balances.",
+            "value_field": [
+                "ecosystem_stablecoin_supply",
+                "ecosystem_bridged_stablecoin_supply",
+            ],
+            "methodology": (
+                "Total stablecoin supply on Solana = native issuance "
+                "(ecosystem_stablecoin_supply) + bridged-in supply "
+                "(ecosystem_bridged_stablecoin_supply). Circulating supply excludes "
+                "issuer treasury and pre-minted, not-yet-issued balances."
+            ),
         },
         "defi_dex_volume": {
             "metric_id": "ecosystem_dex_trading_volume",
@@ -93,6 +104,12 @@ class TokenTerminal(BaseProvider):
     ) -> List[Dict[str, Any]]:
         """Return normalized {"date": str, "value": float} records for the given range (both dates inclusive)."""
         config = self.METRIC_MAP[metric]
+        # A metric may map to one or more Token Terminal metric_ids. When several
+        # are provided (e.g. native + bridged stablecoin supply), their per-day
+        # values are summed into a single figure.
+        value_fields = config["value_field"]
+        if isinstance(value_fields, str):
+            value_fields = [value_fields]
         body = self._get(
             f"/projects/{self.PROJECT}/metrics",
             params={
@@ -108,10 +125,12 @@ class TokenTerminal(BaseProvider):
             row_date = str(row.get(config["date_field"], ""))[:10]
             if not row_date or not (start_date <= row_date <= end_date):
                 continue
-            value = row.get(config["value_field"])
-            if value is None:
+            present = [row.get(field) for field in value_fields]
+            present = [v for v in present if v is not None]
+            if not present:
                 continue
-            result.append({"date": row_date, "value": float(value)})
+            value = sum(float(v) for v in present)
+            result.append({"date": row_date, "value": value})
         return result
 
     def get_metric(

--- a/tests/unit/test_token_terminal_provider.py
+++ b/tests/unit/test_token_terminal_provider.py
@@ -8,7 +8,36 @@ from metrics.stablecoin import Stablecoin, StablecoinMetricType
 from providers.token_terminal import TokenTerminal
 
 
-def test_get_stablecoin_supply_returns_stablecoin_metric() -> None:
+def test_get_stablecoin_supply_sums_native_and_bridged() -> None:
+    provider = TokenTerminal(api_key="test-token-terminal-key")
+    mock_response = [
+        {
+            "timestamp": "2026-01-01T00:00:00.000Z",
+            "ecosystem_stablecoin_supply": 10_987_267_570.64,
+            "ecosystem_bridged_stablecoin_supply": 2_500_000_000.0,
+        },
+    ]
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = mock_response
+    mock_resp.raise_for_status = MagicMock()
+    sentinel_metric = object()
+
+    with (
+        patch.object(provider._session, "get", return_value=mock_resp),
+        patch.object(
+            Stablecoin, "from_metric_type", return_value=sentinel_metric
+        ) as mock_factory,
+    ):
+        result = provider.get_metric("stablecoin_supply", "2026-01-01", "solana")
+
+    assert result is sentinel_metric
+    mock_factory.assert_called_once()
+    assert mock_factory.call_args.kwargs["metric_type"] == StablecoinMetricType.SUPPLY
+    # Total supply = native issuance + bridged-in supply.
+    assert mock_factory.call_args.kwargs["value"] == 13_487_267_570.64
+
+
+def test_get_stablecoin_supply_tolerates_missing_bridged_value() -> None:
     provider = TokenTerminal(api_key="test-token-terminal-key")
     mock_response = [
         {
@@ -30,6 +59,4 @@ def test_get_stablecoin_supply_returns_stablecoin_metric() -> None:
         result = provider.get_metric("stablecoin_supply", "2026-01-01", "solana")
 
     assert result is sentinel_metric
-    mock_factory.assert_called_once()
-    assert mock_factory.call_args.kwargs["metric_type"] == StablecoinMetricType.SUPPLY
     assert mock_factory.call_args.kwargs["value"] == 10_987_267_570.64

--- a/tests/unit/test_token_terminal_provider.py
+++ b/tests/unit/test_token_terminal_provider.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from metrics.stablecoin import Stablecoin, StablecoinMetricType
 from providers.token_terminal import TokenTerminal
 
@@ -34,7 +36,7 @@ def test_get_stablecoin_supply_sums_native_and_bridged() -> None:
     mock_factory.assert_called_once()
     assert mock_factory.call_args.kwargs["metric_type"] == StablecoinMetricType.SUPPLY
     # Total supply = native issuance + bridged-in supply.
-    assert mock_factory.call_args.kwargs["value"] == 13_487_267_570.64
+    assert mock_factory.call_args.kwargs["value"] == pytest.approx(13_487_267_570.64)
 
 
 def test_get_stablecoin_supply_tolerates_missing_bridged_value() -> None:


### PR DESCRIPTION
## Summary

The Token Terminal provider's `stablecoin_supply` metric currently maps to a single metric_id, `ecosystem_stablecoin_supply`, which measures **native stablecoin issuance on Solana only**. Stablecoins bridged onto Solana from other chains are tracked by Token Terminal as a **separate** metric, `ecosystem_bridged_stablecoin_supply`, so they were being left out of the reported figure.

This PR requests both metric_ids in the same call and sums them per day, so the value reflects **total stablecoin supply on Solana (native + bridged)** — matching the headline stablecoin number on Token Terminal's Solana page.

## What changed

- `providers/token_terminal.py`
  - `METRIC_MAP["stablecoin_supply"]` now maps to both metric_ids (`ecosystem_stablecoin_supply,ecosystem_bridged_stablecoin_supply`).
  - `fetch_rows` now accepts a `value_field` that is either a single string (unchanged behavior for every other metric) or a list of fields whose per-day values are summed. Rows are dropped only when *all* requested fields are missing for that day.
  - Updated the methodology note to describe the native + bridged composition.
- `tests/unit/test_token_terminal_provider.py`
  - Added coverage for the native + bridged sum, and a fallback test confirming a day with only the native value still resolves correctly.

No changes to any other provider or metric.

## Why this is the right approach

On Token Terminal's API, native-vs-bridged for ecosystem stablecoin supply is expressed as two separate metric_ids rather than a query parameter. The `bridged=true` flag exists only on the per-asset endpoint (`/v2/assets/{asset_id}/metrics`), not on the project metrics endpoint this provider uses. Summing the two ecosystem metric_ids is the intended way to get a bridged-inclusive total from `/v2/projects/{project_id}/metrics`. Confirmed with the Token Terminal data team.

## Test plan

- [x] `make lint` (ruff + black) — clean on changed files
- [x] `make test` — 86 unit tests pass
- [ ] Optional: run against the live API with a `TOKEN_TERMINAL_API_KEY` to confirm the daily total now includes bridged supply
