### PR TITLE
Use total supply metrics for Blockworks and RWA stablecoin supply.

### DIFF
--- a/providers/blockworks.py
+++ b/providers/blockworks.py
@@ -19,7 +19,7 @@ class Blockworks(BaseProvider):
 
     METRIC_MAP: Dict[str, Dict[str, Any]] = {
         "stablecoin_supply": {
-            "endpoint": "/metrics/stablecoin-circulating-supply-total-usd",
+            "endpoint": "/metrics/stablecoin-supply-total-usd",
             "params": {"project": "solana"},
             "data_path": ["solana"],
             "date_field": "date",

--- a/providers/rwa.py
+++ b/providers/rwa.py
@@ -37,7 +37,7 @@ class Rwa(BaseProvider):
                         {
                             "operator": "equals",
                             "field": "measure_slug",
-                            "value": "circulating_market_value_dollar",
+                            "value": "total_supply_token",
                         },
                     ],
                 },


### PR DESCRIPTION
We were previously using the circulating supply for Blockworks and RWA.
We will now switch the APIs to total supply.