### PR TITLE
Add four overview metrics and validator count to the Token Terminal provider

### DIFF
--- a/providers/token_terminal.py
+++ b/providers/token_terminal.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, List, Optional
 import requests
 
 from metrics.defi import Defi, DefiMetricType
+from metrics.network import Network, NetworkMetricType
 from metrics.overview import Overview, OverviewMetricType
 from metrics.stablecoin import Stablecoin, StablecoinMetricType
 from providers.base import BaseProvider
@@ -61,6 +62,37 @@ class TokenTerminal(BaseProvider):
             "value_field": "ecosystem_dex_trading_volume",
             "methodology": "DEX trade volume varies by indexed venues, pricing, and filtering methodology.",
         },
+        "network_validator_count": {
+            "metric_id": "number_of_validators",
+            "date_field": "timestamp",
+            "value_field": "number_of_validators",
+            "methodology": (
+                "Validators are counted from Solana's native rewards system: an "
+                "address counts for a day if it received a voting reward on that "
+                "day, which only happens for validators taking part in consensus. "
+                "Validators that were delinquent for the whole day therefore drop "
+                "out of the count."
+            ),
+        },
+    }
+
+    _OVERVIEW_METRIC_TYPE_MAP: Dict[str, OverviewMetricType] = {
+        "overview_tx_count_total": OverviewMetricType.TX_COUNT_TOTAL,
+        "overview_tx_count_vote": OverviewMetricType.TX_COUNT_VOTE,
+        "overview_sol_price": OverviewMetricType.SOL_PRICE,
+        "overview_fee_payers": OverviewMetricType.FEE_PAYERS,
+    }
+
+    _STABLECOIN_METRIC_TYPE_MAP: Dict[str, StablecoinMetricType] = {
+        "stablecoin_supply": StablecoinMetricType.SUPPLY,
+    }
+
+    _DEFI_METRIC_TYPE_MAP: Dict[str, DefiMetricType] = {
+        "defi_dex_volume": DefiMetricType.DEX_VOLUME,
+    }
+
+    _NETWORK_METRIC_TYPE_MAP: Dict[str, NetworkMetricType] = {
+        "network_validator_count": NetworkMetricType.VALIDATOR_COUNT,
     }
 
     BASE_URL = "https://api.tokenterminal.com/v2"
@@ -140,43 +172,36 @@ class TokenTerminal(BaseProvider):
 
     def get_metric(
         self, metric: str, date: str, chain: str
-    ) -> Stablecoin | Overview | Defi | None:
+    ) -> Stablecoin | Overview | Defi | Network | None:
         """Fetch one metric value and return it as a typed metric model."""
         rows = self.fetch_rows(metric, date, date)
         if not rows:
             return None
-
         value = rows[0]["value"]
         parsed_date = datetime.date.fromisoformat(date)
 
-        overview_metric_map: Dict[str, OverviewMetricType] = {
-            "overview_tx_count_total": OverviewMetricType.TX_COUNT_TOTAL,
-            "overview_tx_count_vote": OverviewMetricType.TX_COUNT_VOTE,
-            "overview_sol_price": OverviewMetricType.SOL_PRICE,
-            "overview_fee_payers": OverviewMetricType.FEE_PAYERS,
-        }
-        if metric in overview_metric_map:
+        overview_type = self._OVERVIEW_METRIC_TYPE_MAP.get(metric)
+        if overview_type is not None:
             return Overview.from_metric_type(
-                metric_type=overview_metric_map[metric],
-                date=parsed_date,
-                value=value,
+                metric_type=overview_type, date=parsed_date, value=value
             )
 
-        defi_metric_map: Dict[str, DefiMetricType] = {
-            "defi_dex_volume": DefiMetricType.DEX_VOLUME,
-        }
-        if metric in defi_metric_map:
+        stablecoin_type = self._STABLECOIN_METRIC_TYPE_MAP.get(metric)
+        if stablecoin_type is not None:
+            return Stablecoin.from_metric_type(
+                metric_type=stablecoin_type, date=parsed_date, value=value
+            )
+
+        defi_type = self._DEFI_METRIC_TYPE_MAP.get(metric)
+        if defi_type is not None:
             return Defi.from_metric_type(
-                metric_type=defi_metric_map[metric],
-                date=parsed_date,
-                value=value,
+                metric_type=defi_type, date=parsed_date, value=value
             )
 
-        stablecoin_metric_map: Dict[str, StablecoinMetricType] = {
-            "stablecoin_supply": StablecoinMetricType.SUPPLY,
-        }
-        return Stablecoin.from_metric_type(
-            metric_type=stablecoin_metric_map[metric],
-            date=parsed_date,
-            value=value,
-        )
+        network_type = self._NETWORK_METRIC_TYPE_MAP.get(metric)
+        if network_type is not None:
+            return Network.from_metric_type(
+                metric_type=network_type, date=parsed_date, value=value
+            )
+
+        return None

--- a/providers/token_terminal.py
+++ b/providers/token_terminal.py
@@ -39,6 +39,47 @@ class TokenTerminal(BaseProvider):
             "date_field": "timestamp",
             "value_field": "active_addresses_daily",
         },
+        "overview_non_vote_tx_count_success": {
+            "metric_id": "successful_non_vote_transaction_count",
+            "date_field": "timestamp",
+            "value_field": "successful_non_vote_transaction_count",
+            "methodology": (
+                "Non-vote transactions that executed without error, aggregated from "
+                "the per-block counts Solana records. Sums with the failed count to "
+                "the total non-vote transaction count."
+            ),
+        },
+        "overview_non_vote_tx_count_failed": {
+            "metric_id": "failed_non_vote_transaction_count",
+            "date_field": "timestamp",
+            "value_field": "failed_non_vote_transaction_count",
+            "methodology": (
+                "Non-vote transactions that reverted with an error. They were "
+                "included in a block and paid a fee, so this counts wasted execution "
+                "rather than dropped demand."
+            ),
+        },
+        "overview_slots": {
+            "metric_id": "slot_count",
+            "date_field": "timestamp",
+            "value_field": "slot_count",
+            "methodology": (
+                "Slots in which a leader produced a block. Skipped slots are "
+                "excluded, so the shortfall against the slot schedule is the leader "
+                "skip rate."
+            ),
+        },
+        "overview_compute_units": {
+            "metric_id": "compute_units_per_block",
+            "date_field": "timestamp",
+            "value_field": "compute_units_per_block",
+            "methodology": (
+                "Average compute units consumed per produced block. Both successful "
+                "and failed non-vote transactions count, since failed transactions "
+                "still consume compute. Blocks carrying no transactions remain in "
+                "the denominator because they still occupied a slot."
+            ),
+        },
         "stablecoin_supply": {
             # Total stablecoin supply = native issuance + bridged-in supply.
             # Token Terminal exposes these as two separate metric_ids; requesting
@@ -81,6 +122,10 @@ class TokenTerminal(BaseProvider):
         "overview_tx_count_vote": OverviewMetricType.TX_COUNT_VOTE,
         "overview_sol_price": OverviewMetricType.SOL_PRICE,
         "overview_fee_payers": OverviewMetricType.FEE_PAYERS,
+        "overview_non_vote_tx_count_success": OverviewMetricType.TX_COUNT_NON_VOTE_SUCCESS,
+        "overview_non_vote_tx_count_failed": OverviewMetricType.TX_COUNT_NON_VOTE_FAILED,
+        "overview_slots": OverviewMetricType.SLOTS,
+        "overview_compute_units": OverviewMetricType.COMPUTE_UNITS,
     }
 
     _STABLECOIN_METRIC_TYPE_MAP: Dict[str, StablecoinMetricType] = {

--- a/tests/integration/test_token_terminal_provider_integration.py
+++ b/tests/integration/test_token_terminal_provider_integration.py
@@ -8,6 +8,7 @@ import pytest
 from dotenv import load_dotenv
 
 from metrics.network import Network, NetworkMetricType
+from metrics.overview import Overview, OverviewMetricType
 from metrics.stablecoin import Stablecoin, StablecoinMetricType
 from providers.token_terminal import TokenTerminal
 
@@ -55,3 +56,50 @@ def test_get_validator_count_live_api() -> None:
     assert isinstance(metric, Network)
     assert metric.metric_type == NetworkMetricType.VALIDATOR_COUNT
     assert metric.value > 0
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    ("metric", "metric_type", "low", "high"),
+    [
+        ("overview_slots", OverviewMetricType.SLOTS, 150_000, 250_000),
+        (
+            "overview_non_vote_tx_count_success",
+            OverviewMetricType.TX_COUNT_NON_VOTE_SUCCESS,
+            10_000_000,
+            500_000_000,
+        ),
+        (
+            "overview_non_vote_tx_count_failed",
+            OverviewMetricType.TX_COUNT_NON_VOTE_FAILED,
+            1_000_000,
+            500_000_000,
+        ),
+        (
+            "overview_compute_units",
+            OverviewMetricType.COMPUTE_UNITS,
+            5_000_000,
+            100_000_000,
+        ),
+    ],
+)
+def test_overview_metrics_live_api(
+    metric: str, metric_type: OverviewMetricType, low: int, high: int
+) -> None:
+    """Each new overview metric resolves against the live API and is in range.
+
+    The bounds are wide on purpose: they catch a wrong metric_id or value_field,
+    which would otherwise surface as an empty series rather than an error.
+    """
+    if not API_KEY:
+        pytest.skip(
+            "Set TOKEN_TERMINAL_API_KEY to run live Token Terminal integration tests."
+        )
+
+    provider = TokenTerminal(api_key=API_KEY)
+    result = provider.get_metric(metric=metric, date="2026-08-03", chain="solana")
+
+    assert result is not None
+    assert isinstance(result, Overview)
+    assert result.metric_type == metric_type
+    assert low < result.value < high

--- a/tests/integration/test_token_terminal_provider_integration.py
+++ b/tests/integration/test_token_terminal_provider_integration.py
@@ -7,6 +7,7 @@ import os
 import pytest
 from dotenv import load_dotenv
 
+from metrics.network import Network, NetworkMetricType
 from metrics.stablecoin import Stablecoin, StablecoinMetricType
 from providers.token_terminal import TokenTerminal
 
@@ -33,3 +34,24 @@ def test_get_stablecoin_supply_live_api() -> None:
     assert isinstance(metric, Stablecoin)
     assert metric.metric_type == StablecoinMetricType.SUPPLY
     assert metric.value >= 0
+
+
+@pytest.mark.integration
+def test_get_validator_count_live_api() -> None:
+    """Validator count is served on the network page and must be a positive count."""
+    if not API_KEY:
+        pytest.skip(
+            "Set TOKEN_TERMINAL_API_KEY to run live Token Terminal integration tests."
+        )
+
+    provider = TokenTerminal(api_key=API_KEY)
+    metric = provider.get_metric(
+        metric="network_validator_count",
+        date="2025-01-01",
+        chain="solana",
+    )
+
+    assert metric is not None
+    assert isinstance(metric, Network)
+    assert metric.metric_type == NetworkMetricType.VALIDATOR_COUNT
+    assert metric.value > 0

--- a/tests/unit/test_token_terminal_provider.py
+++ b/tests/unit/test_token_terminal_provider.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from metrics.network import Network, NetworkMetricType
 from metrics.stablecoin import Stablecoin, StablecoinMetricType
 from providers.token_terminal import TokenTerminal
 
@@ -62,3 +63,41 @@ def test_get_stablecoin_supply_tolerates_missing_bridged_value() -> None:
 
     assert result is sentinel_metric
     assert mock_factory.call_args.kwargs["value"] == 10_987_267_570.64
+
+
+def test_get_validator_count_returns_network_metric() -> None:
+    provider = TokenTerminal(api_key="test-token-terminal-key")
+    mock_response = [
+        {"timestamp": "2026-01-01T00:00:00.000Z", "number_of_validators": 683},
+    ]
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = mock_response
+    mock_resp.raise_for_status = MagicMock()
+    sentinel_metric = object()
+
+    with (
+        patch.object(provider._session, "get", return_value=mock_resp),
+        patch.object(
+            Network, "from_metric_type", return_value=sentinel_metric
+        ) as mock_factory,
+    ):
+        result = provider.get_metric("network_validator_count", "2026-01-01", "solana")
+
+    assert result is sentinel_metric
+    mock_factory.assert_called_once()
+    assert (
+        mock_factory.call_args.kwargs["metric_type"]
+        == NetworkMetricType.VALIDATOR_COUNT
+    )
+    assert mock_factory.call_args.kwargs["value"] == 683
+
+
+def test_every_supported_metric_has_a_metric_type() -> None:
+    """Each entry in METRIC_MAP must resolve to a typed metric model."""
+    mapped = (
+        set(TokenTerminal._OVERVIEW_METRIC_TYPE_MAP)
+        | set(TokenTerminal._STABLECOIN_METRIC_TYPE_MAP)
+        | set(TokenTerminal._DEFI_METRIC_TYPE_MAP)
+        | set(TokenTerminal._NETWORK_METRIC_TYPE_MAP)
+    )
+    assert set(TokenTerminal.METRIC_MAP) == mapped

--- a/tests/unit/test_token_terminal_provider.py
+++ b/tests/unit/test_token_terminal_provider.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from metrics.network import Network, NetworkMetricType
+from metrics.overview import Overview, OverviewMetricType
 from metrics.stablecoin import Stablecoin, StablecoinMetricType
 from providers.token_terminal import TokenTerminal
 
@@ -90,6 +91,61 @@ def test_get_validator_count_returns_network_metric() -> None:
         == NetworkMetricType.VALIDATOR_COUNT
     )
     assert mock_factory.call_args.kwargs["value"] == 683
+
+
+@pytest.mark.parametrize(
+    ("metric", "value_field", "value", "metric_type"),
+    [
+        (
+            "overview_slots",
+            "slot_count",
+            203507,
+            OverviewMetricType.SLOTS,
+        ),
+        (
+            "overview_non_vote_tx_count_success",
+            "successful_non_vote_transaction_count",
+            89424992,
+            OverviewMetricType.TX_COUNT_NON_VOTE_SUCCESS,
+        ),
+        (
+            "overview_non_vote_tx_count_failed",
+            "failed_non_vote_transaction_count",
+            63705940,
+            OverviewMetricType.TX_COUNT_NON_VOTE_FAILED,
+        ),
+        (
+            "overview_compute_units",
+            "compute_units_per_block",
+            33179623,
+            OverviewMetricType.COMPUTE_UNITS,
+        ),
+    ],
+)
+def test_overview_metrics_map_to_their_metric_type(
+    metric: str, value_field: str, value: int, metric_type: OverviewMetricType
+) -> None:
+    """Each overview metric reads its own response field and types correctly."""
+    provider = TokenTerminal(api_key="test-token-terminal-key")
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = [
+        {"timestamp": "2026-08-03T00:00:00.000Z", value_field: value}
+    ]
+    mock_resp.raise_for_status = MagicMock()
+    sentinel_metric = object()
+
+    with (
+        patch.object(provider._session, "get", return_value=mock_resp),
+        patch.object(
+            Overview, "from_metric_type", return_value=sentinel_metric
+        ) as mock_factory,
+    ):
+        result = provider.get_metric(metric, "2026-08-03", "solana")
+
+    assert result is sentinel_metric
+    mock_factory.assert_called_once()
+    assert mock_factory.call_args.kwargs["metric_type"] == metric_type
+    assert mock_factory.call_args.kwargs["value"] == value
 
 
 def test_every_supported_metric_has_a_metric_type() -> None:


### PR DESCRIPTION
## Summary

Adds five Solana metrics to the Token Terminal provider, taking it from 6 charts to **11** and from three metric pages to all four.

| Page | Chart | Token Terminal `metric_id` |
|---|---|---|
| Overview | Slots | `slot_count` |
| Overview | Non Vote Transaction Count (Success) | `successful_non_vote_transaction_count` |
| Overview | Non Vote Transaction Count (Failed) | `failed_non_vote_transaction_count` |
| Overview | Compute Units | `compute_units_per_block` |
| Network | Validator Count | `number_of_validators` |

The four overview metrics are new on Token Terminal's side. We built and released them on 2026-08-04 specifically to fill these charts, so the overview page is now complete apart from Fees, which we publish in USD rather than SOL.

## Verified against the live API

Every value below was fetched through this provider from `api.tokenterminal.com`, not computed locally:

| Metric | 2026-08-01 | 2026-08-02 | 2026-08-03 |
|---|---|---|---|
| Slots | 204,426 | 204,520 | 203,507 |
| Non-vote success | 73,204,229 | 76,668,577 | 89,424,992 |
| Non-vote failed | 46,517,031 | 46,538,283 | 63,705,940 |
| Compute units / block | 24,693,760 | 26,763,848 | 33,179,623 |
| Validator count | | | 683 |

These sit inside the ranges the other providers on this dashboard report for the same period: slots ~203 to 205K, non-vote success ~75 to 95M, non-vote failed ~45 to 62M, compute units ~28 to 35M.

Two independent cross-checks:

- **Solana RPC.** `getBlockProduction` reports 8,933 leader slots against 8,919 produced for the current epoch, a 0.157% skip rate implying roughly 201,623 blocks per day. Our 90-day range brackets that figure.
- **Internal identity.** Across all 378,199,935 blocks of Solana history, `successful + failed` equals the `non_vote_transaction_count` we already serve on every block but 917, all of them on a single day in March 2021 (a 0.019% gap that day).

## Methodology notes

**Slots** counts produced blocks, so skipped slots are excluded. This matches what the other providers on this chart report. The shortfall against the slot schedule is the leader skip rate, averaging 0.195% over the last 90 days.

**Compute units** counts both successful and failed non-vote transactions, because failed transactions still consume compute. Solana stores those separately, and omitting the failed side understates the figure by roughly 40%. Vote transactions are excluded, as we do not index them.

**Validator count** is derived from Solana's voting rewards: an address counts for a day if it received a voting reward. This is a true daily history, whereas Stakewiz and Validators.app aggregate a live snapshot filtered on current delinquency.

## What changed

- `providers/token_terminal.py`: four new `METRIC_MAP` entries plus their metric types. The earlier commit adds `network_validator_count` and converts the metric-type dicts inside `get_metric` into per-page private class constants, matching `topledger.py` and `uniblock.py`.
- `tests/unit/`: parametrized coverage for the four new metrics, plus an invariant test asserting every `METRIC_MAP` key resolves to a metric type.
- `tests/integration/`: live-API coverage for all five, with deliberately wide bounds so a wrong `metric_id` or `value_field` fails loudly instead of returning an empty series.

## Test plan

- [x] `ruff check .` is clean
- [x] `black --check` on the changed files is clean
- [x] `make test`: 122 unit tests pass
- [x] `make test-integration`: 6 live API tests pass against `api.tokenterminal.com`

Heads-up on `make lint`: `black --check` already fails on `main` for four unrelated files (`providers/birdeye.py`, `providers/topledger.py`, and their tests). Left untouched to keep this diff scoped, so those failures are not from this PR.
