### PR TITLE
Split Stablecoin Supply into Total and  Circulating Supply

### DIFF
--- a/metrics/stablecoin.py
+++ b/metrics/stablecoin.py
@@ -13,7 +13,8 @@ from metrics.base import BaseMetric
 class StablecoinMetricType(str, Enum):
     """Supported stablecoin metric categories."""
 
-    SUPPLY = "supply"
+    TOTAL_SUPPLY = "total_supply"
+    CIRCULATING_SUPPLY = "circulating_supply"
     TRANSFER_VOLUME = "transfer_volume"
     TRANSFER_COUNT = "transfer_count"
     ACTIVE_ADDRESSES = "active_addresses"
@@ -21,10 +22,15 @@ class StablecoinMetricType(str, Enum):
 
 
 _METRIC_METADATA: dict[StablecoinMetricType, dict[str, str]] = {
-    StablecoinMetricType.SUPPLY: {
-        "name": "Supply",
+    StablecoinMetricType.TOTAL_SUPPLY: {
+        "name": "Total Supply",
         "unit": "USD",
-        "description": "Total circulating supply of stablecoins on Solana, denominated in USD",
+        "description": "Total stablecoin supply on Solana, denominated in USD, including non-circulating treasury and pre-minted balances",
+    },
+    StablecoinMetricType.CIRCULATING_SUPPLY: {
+        "name": "Circulating Supply",
+        "unit": "USD",
+        "description": "Circulating supply of stablecoins on Solana, denominated in USD, excluding issuer treasury and locked balances",
     },
     StablecoinMetricType.TRANSFER_VOLUME: {
         "name": "Transfer Volume",

--- a/providers/allium.py
+++ b/providers/allium.py
@@ -19,14 +19,27 @@ class Allium(BaseProvider):
     """Fetch stablecoin metrics from the Allium Explorer API."""
 
     METRIC_MAP: Dict[str, Dict[str, str]] = {
-        "stablecoin_supply": {
+        "stablecoin_total_supply": {
             "date_field": "date",
             "value_field": "usd",
-            "methodology": "Net mints minus burns, excluding treasury and locked balances.",
             "sql": """
                 SELECT
                     date,
                     SUM(total_supply_usd) AS usd
+                FROM solana.stablecoins.supply_distribution_daily
+                WHERE date >= DATE '{start_date}'
+                  AND date < DATEADD('day', 1, DATE '{end_date}')
+                GROUP BY ALL
+                ORDER BY date
+            """,
+        },
+        "stablecoin_circulating_supply": {
+            "date_field": "date",
+            "value_field": "usd",
+            "sql": """
+                SELECT
+                    date,
+                    SUM(circulating_supply_usd) AS usd
                 FROM solana.stablecoins.supply_distribution_daily
                 WHERE date >= DATE '{start_date}'
                   AND date < DATEADD('day', 1, DATE '{end_date}')
@@ -454,7 +467,8 @@ class Allium(BaseProvider):
             )
 
         stablecoin_metric_map = {
-            "stablecoin_supply": StablecoinMetricType.SUPPLY,
+            "stablecoin_total_supply": StablecoinMetricType.TOTAL_SUPPLY,
+            "stablecoin_circulating_supply": StablecoinMetricType.CIRCULATING_SUPPLY,
             "stablecoin_transfer_volume": StablecoinMetricType.TRANSFER_VOLUME,
             "stablecoin_transfer_count": StablecoinMetricType.TRANSFER_COUNT,
             "stablecoin_active_addresses": StablecoinMetricType.ACTIVE_ADDRESSES,

--- a/providers/artemis.py
+++ b/providers/artemis.py
@@ -22,7 +22,6 @@ class Artemis(BaseProvider):
     """Fetch stablecoin metrics from the Artemis XYZ API."""
 
     METRIC_MAP: Dict[str, Dict[str, Any]] = {
-        "stablecoin_supply": {"endpoint": "STABLECOIN_SUPPLY"},
         "stablecoin_transfer_volume": {"endpoint": "STABLECOIN_TRANSFER_VOLUME"},
         "stablecoin_transfer_count": {"endpoint": "STABLECOIN_DAILY_TXNS"},
         "stablecoin_active_addresses": {"endpoint": "STABLECOIN_DAU"},
@@ -132,7 +131,6 @@ class Artemis(BaseProvider):
             )
 
         stablecoin_metric_map = {
-            "stablecoin_supply": StablecoinMetricType.SUPPLY,
             "stablecoin_transfer_volume": StablecoinMetricType.TRANSFER_VOLUME,
             "stablecoin_transfer_count": StablecoinMetricType.TRANSFER_COUNT,
             "stablecoin_active_addresses": StablecoinMetricType.ACTIVE_ADDRESSES,

--- a/providers/artemis.py
+++ b/providers/artemis.py
@@ -22,6 +22,9 @@ class Artemis(BaseProvider):
     """Fetch stablecoin metrics from the Artemis XYZ API."""
 
     METRIC_MAP: Dict[str, Dict[str, Any]] = {
+        "stablecoin_circulating_supply": {
+            "endpoint": "STABLECOIN_SUPPLY",
+        },
         "stablecoin_transfer_volume": {"endpoint": "STABLECOIN_TRANSFER_VOLUME"},
         "stablecoin_transfer_count": {"endpoint": "STABLECOIN_DAILY_TXNS"},
         "stablecoin_active_addresses": {"endpoint": "STABLECOIN_DAU"},
@@ -131,6 +134,7 @@ class Artemis(BaseProvider):
             )
 
         stablecoin_metric_map = {
+            "stablecoin_circulating_supply": StablecoinMetricType.CIRCULATING_SUPPLY,
             "stablecoin_transfer_volume": StablecoinMetricType.TRANSFER_VOLUME,
             "stablecoin_transfer_count": StablecoinMetricType.TRANSFER_COUNT,
             "stablecoin_active_addresses": StablecoinMetricType.ACTIVE_ADDRESSES,

--- a/providers/birdeye.py
+++ b/providers/birdeye.py
@@ -20,7 +20,7 @@ class Birdeye(BaseProvider):
         "overview_sol_price": {
             "endpoint": "/defi/history_price",
         },
-        "stablecoin_supply": {
+        "stablecoin_circulating_supply": {
             "endpoint": "/market/v1/blockchain-metrics",
             "metric_field": "stable_coin_market_cap",
             "methodology": "Total circulating supply, priced and aggregated across stablecoins.",
@@ -95,7 +95,7 @@ class Birdeye(BaseProvider):
             )
 
         stablecoin_metric_map = {
-            "stablecoin_supply": StablecoinMetricType.SUPPLY,
+            "stablecoin_circulating_supply": StablecoinMetricType.CIRCULATING_SUPPLY,
         }
         if metric in stablecoin_metric_map:
             return Stablecoin.from_metric_type(
@@ -159,7 +159,7 @@ class Birdeye(BaseProvider):
                                 }
                             )
 
-            case "stablecoin_supply" | "defi_dex_volume" | "defi_dex_transactions":
+            case "stablecoin_circulating_supply" | "defi_dex_volume" | "defi_dex_transactions":
                 while start_timestamp <= end_timestamp:
                     count = min(10, (end_timestamp - start_timestamp) // self.ONE_DAY_SECONDS + 1)
                     response = self._get(

--- a/providers/blockworks.py
+++ b/providers/blockworks.py
@@ -18,7 +18,7 @@ class Blockworks(BaseProvider):
     """Fetch stablecoin metrics from the Blockworks Research API."""
 
     METRIC_MAP: Dict[str, Dict[str, Any]] = {
-        "stablecoin_supply": {
+        "stablecoin_total_supply": {
             "endpoint": "/metrics/stablecoin-supply-total-usd",
             "params": {"project": "solana"},
             "data_path": ["solana"],
@@ -292,7 +292,7 @@ class Blockworks(BaseProvider):
             )
 
         stablecoin_metric_map = {
-            "stablecoin_supply": StablecoinMetricType.SUPPLY,
+            "stablecoin_total_supply": StablecoinMetricType.TOTAL_SUPPLY,
             "stablecoin_transfer_volume": StablecoinMetricType.TRANSFER_VOLUME,
             "stablecoin_transfer_count": StablecoinMetricType.TRANSFER_COUNT,
             "stablecoin_active_addresses": StablecoinMetricType.ACTIVE_ADDRESSES,

--- a/providers/defillama.py
+++ b/providers/defillama.py
@@ -18,7 +18,7 @@ class DefiLlama(BaseProvider):
     """Fetch stablecoin metrics from the DefiLlama API."""
 
     METRIC_MAP: Dict[str, Dict[str, Any]] = {
-        "stablecoin_supply": {
+        "stablecoin_circulating_supply": {
             "endpoint": "/stablecoins/stablecoincharts/solana",
             "value_path": ["totalCirculating", "peggedUSD"],
             "methodology": "Bridge-aware circulating supply, priced and aggregated across stablecoins and peg types.",
@@ -223,7 +223,7 @@ class DefiLlama(BaseProvider):
             )
 
         stablecoin_metric_map = {
-            "stablecoin_supply": StablecoinMetricType.SUPPLY,
+            "stablecoin_circulating_supply": StablecoinMetricType.CIRCULATING_SUPPLY,
             "stablecoin_transfer_volume": StablecoinMetricType.TRANSFER_VOLUME,
             "stablecoin_count": StablecoinMetricType.COUNT,
         }

--- a/providers/dune.py
+++ b/providers/dune.py
@@ -19,7 +19,7 @@ class Dune(BaseProvider):
     """Fetch stablecoin metrics from the Dune SQL API."""
 
     METRIC_MAP: Dict[str, Dict[str, str]] = {
-        "stablecoin_supply": {
+        "stablecoin_total_supply": {
             "date_field": "day",
             "value_field": "total_supply_usd",
             "sql": """
@@ -31,6 +31,19 @@ class Dune(BaseProvider):
                   AND b.day BETWEEN DATE '{start_date}' AND DATE '{end_date}'
                 GROUP BY b.day
                 ORDER BY b.day ASC
+            """,
+        },
+        "stablecoin_circulating_supply": {
+            "date_field": "day",
+            "value_field": "circulating_supply_usd",
+            "sql": """
+                SELECT
+                    day,
+                    SUM(circulating_supply_usd) AS circulating_supply_usd
+                FROM solana_team.stablecoins_solana_circulating_supply
+                WHERE day BETWEEN DATE '{start_date}' AND DATE '{end_date}'
+                GROUP BY day
+                ORDER BY day ASC
             """,
         },
         "stablecoin_transfer_volume": {
@@ -433,7 +446,8 @@ class Dune(BaseProvider):
             )
 
         stablecoin_metric_map = {
-            "stablecoin_supply": StablecoinMetricType.SUPPLY,
+            "stablecoin_total_supply": StablecoinMetricType.TOTAL_SUPPLY,
+            "stablecoin_circulating_supply": StablecoinMetricType.CIRCULATING_SUPPLY,
             "stablecoin_transfer_volume": StablecoinMetricType.TRANSFER_VOLUME,
             "stablecoin_transfer_count": StablecoinMetricType.TRANSFER_COUNT,
             "stablecoin_active_addresses": StablecoinMetricType.ACTIVE_ADDRESSES,

--- a/providers/rwa.py
+++ b/providers/rwa.py
@@ -19,7 +19,7 @@ class Rwa(BaseProvider):
     """Fetch metrics from the RWA data provider."""
 
     METRIC_MAP: Dict[str, Dict[str, Any]] = {
-        "stablecoin_supply": {
+        "stablecoin_total_supply": {
             "query": {
                 "filter": {
                     "operator": "and",
@@ -225,7 +225,7 @@ class Rwa(BaseProvider):
         parsed_date = datetime.date.fromisoformat(date)
 
         stablecoin_metric_map = {
-            "stablecoin_supply": StablecoinMetricType.SUPPLY,
+            "stablecoin_total_supply": StablecoinMetricType.TOTAL_SUPPLY,
             "stablecoin_transfer_volume": StablecoinMetricType.TRANSFER_VOLUME,
             "stablecoin_transfer_count": StablecoinMetricType.TRANSFER_COUNT,
             "stablecoin_active_addresses": StablecoinMetricType.ACTIVE_ADDRESSES,

--- a/providers/token_terminal.py
+++ b/providers/token_terminal.py
@@ -80,7 +80,7 @@ class TokenTerminal(BaseProvider):
                 "the denominator because they still occupied a slot."
             ),
         },
-        "stablecoin_supply": {
+        "stablecoin_total_supply": {
             # Total stablecoin supply = native issuance + bridged-in supply.
             # Token Terminal exposes these as two separate metric_ids; requesting
             # both in one call and summing them yields the bridged-inclusive total.
@@ -129,7 +129,7 @@ class TokenTerminal(BaseProvider):
     }
 
     _STABLECOIN_METRIC_TYPE_MAP: Dict[str, StablecoinMetricType] = {
-        "stablecoin_supply": StablecoinMetricType.SUPPLY,
+        "stablecoin_total_supply": StablecoinMetricType.TOTAL_SUPPLY,
     }
 
     _DEFI_METRIC_TYPE_MAP: Dict[str, DefiMetricType] = {

--- a/providers/topledger.py
+++ b/providers/topledger.py
@@ -71,7 +71,7 @@ class TopLedger(BaseProvider):
             "value_field": "fee_payer",
             "methodology": "Unique signers of non-vote transactions",
         },
-        "stablecoin_supply": {
+        "stablecoin_circulating_supply": {
             "query_id": 15090,
             "date_field": "block_date",
             "value_field": "marketcap",
@@ -136,7 +136,7 @@ class TopLedger(BaseProvider):
     }
 
     _STABLECOIN_METRIC_TYPE_MAP: Dict[str, StablecoinMetricType] = {
-        "stablecoin_supply": StablecoinMetricType.SUPPLY,
+        "stablecoin_circulating_supply": StablecoinMetricType.CIRCULATING_SUPPLY,
         "stablecoin_count": StablecoinMetricType.COUNT,
         "stablecoin_transfer_volume": StablecoinMetricType.TRANSFER_VOLUME,
         "stablecoin_transfer_count": StablecoinMetricType.TRANSFER_COUNT,

--- a/tests/integration/test_allium_provider_integration.py
+++ b/tests/integration/test_allium_provider_integration.py
@@ -15,19 +15,19 @@ API_KEY = os.environ.get("ALLIUM_API_KEY")
 
 
 @pytest.mark.integration
-def test_get_stablecoin_supply_live_api() -> None:
+def test_get_stablecoin_circulating_supply_live_api() -> None:
     """Calls Allium API directly and validates response mapping."""
     if not API_KEY:
         pytest.skip("Set ALLIUM_API_KEY to run live Allium integration tests.")
 
     provider = Allium(api_key=API_KEY)
     metric = provider.get_metric(
-        metric="stablecoin_supply",
+        metric="stablecoin_circulating_supply",
         date="2025-01-01",
         chain="solana",
     )
 
     assert metric is not None
     assert isinstance(metric, Stablecoin)
-    assert metric.metric_type == StablecoinMetricType.SUPPLY
+    assert metric.metric_type == StablecoinMetricType.CIRCULATING_SUPPLY
     assert metric.value >= 0

--- a/tests/integration/test_artemis_provider_integration.py
+++ b/tests/integration/test_artemis_provider_integration.py
@@ -4,30 +4,33 @@ from __future__ import annotations
 
 import os
 
-import pytest
+import pytest  # noqa: F401
 from dotenv import load_dotenv
 
-from metrics.stablecoin import Stablecoin, StablecoinMetricType
-from providers.artemis import Artemis
+from metrics.stablecoin import Stablecoin, StablecoinMetricType  # noqa: F401
+from providers.artemis import Artemis  # noqa: F401
 
 load_dotenv()
 API_KEY = os.environ.get("ARTEMIS_API_KEY")
 
 
-@pytest.mark.integration
-def test_get_stablecoin_supply_live_api() -> None:
-    """Calls Artemis API directly and validates response mapping."""
-    if not API_KEY:
-        pytest.skip("Set ARTEMIS_API_KEY to run live Artemis integration tests.")
-
-    provider = Artemis(api_key=API_KEY)
-    metric = provider.get_metric(
-        metric="stablecoin_supply",
-        date="2025-01-01",
-        chain="solana",
-    )
-
-    assert metric is not None
-    assert isinstance(metric, Stablecoin)
-    assert metric.metric_type == StablecoinMetricType.SUPPLY
-    assert metric.value >= 0
+# stablecoin_supply is intentionally out of Artemis's METRIC_MAP until they
+# confirm whether STABLECOIN_SUPPLY is circulating or total supply -- see
+# providers/artemis.py. Commented out rather than removed until that answer.
+# @pytest.mark.integration
+# def test_get_stablecoin_supply_live_api() -> None:
+#     """Calls Artemis API directly and validates response mapping."""
+#     if not API_KEY:
+#         pytest.skip("Set ARTEMIS_API_KEY to run live Artemis integration tests.")
+#
+#     provider = Artemis(api_key=API_KEY)
+#     metric = provider.get_metric(
+#         metric="stablecoin_supply",
+#         date="2025-01-01",
+#         chain="solana",
+#     )
+#
+#     assert metric is not None
+#     assert isinstance(metric, Stablecoin)
+#     assert metric.metric_type == StablecoinMetricType.SUPPLY
+#     assert metric.value >= 0

--- a/tests/integration/test_artemis_provider_integration.py
+++ b/tests/integration/test_artemis_provider_integration.py
@@ -4,33 +4,30 @@ from __future__ import annotations
 
 import os
 
-import pytest  # noqa: F401
+import pytest
 from dotenv import load_dotenv
 
-from metrics.stablecoin import Stablecoin, StablecoinMetricType  # noqa: F401
-from providers.artemis import Artemis  # noqa: F401
+from metrics.stablecoin import Stablecoin, StablecoinMetricType
+from providers.artemis import Artemis
 
 load_dotenv()
 API_KEY = os.environ.get("ARTEMIS_API_KEY")
 
 
-# stablecoin_supply is intentionally out of Artemis's METRIC_MAP until they
-# confirm whether STABLECOIN_SUPPLY is circulating or total supply -- see
-# providers/artemis.py. Commented out rather than removed until that answer.
-# @pytest.mark.integration
-# def test_get_stablecoin_supply_live_api() -> None:
-#     """Calls Artemis API directly and validates response mapping."""
-#     if not API_KEY:
-#         pytest.skip("Set ARTEMIS_API_KEY to run live Artemis integration tests.")
-#
-#     provider = Artemis(api_key=API_KEY)
-#     metric = provider.get_metric(
-#         metric="stablecoin_supply",
-#         date="2025-01-01",
-#         chain="solana",
-#     )
-#
-#     assert metric is not None
-#     assert isinstance(metric, Stablecoin)
-#     assert metric.metric_type == StablecoinMetricType.SUPPLY
-#     assert metric.value >= 0
+@pytest.mark.integration
+def test_get_stablecoin_circulating_supply_live_api() -> None:
+    """Calls Artemis API directly and validates response mapping."""
+    if not API_KEY:
+        pytest.skip("Set ARTEMIS_API_KEY to run live Artemis integration tests.")
+
+    provider = Artemis(api_key=API_KEY)
+    metric = provider.get_metric(
+        metric="stablecoin_circulating_supply",
+        date="2025-01-01",
+        chain="solana",
+    )
+
+    assert metric is not None
+    assert isinstance(metric, Stablecoin)
+    assert metric.metric_type == StablecoinMetricType.CIRCULATING_SUPPLY
+    assert metric.value >= 0

--- a/tests/integration/test_birdeye_provider_integration.py
+++ b/tests/integration/test_birdeye_provider_integration.py
@@ -38,18 +38,18 @@ def test_get_sol_price_live_api() -> None:
     assert metric.value > 0
 
 @pytest.mark.integration
-def test_get_stablecoin_supply_live_api() -> None:
-    """Stablecoin supply for Solana should be a positive value."""
+def test_get_stablecoin_circulating_supply_live_api() -> None:
+    """Stablecoin circulating supply for Solana should be a positive value."""
     provider = Birdeye(api_key=API_KEY)
     metric = provider.get_metric(
-        metric="stablecoin_supply",
+        metric="stablecoin_circulating_supply",
         date=_TODAY_STR,
         chain="solana",
     )
 
     assert metric is not None
     assert isinstance(metric, Stablecoin)
-    assert metric.metric_type == StablecoinMetricType.SUPPLY
+    assert metric.metric_type == StablecoinMetricType.CIRCULATING_SUPPLY
     assert metric.value > 0
 
 @pytest.mark.integration

--- a/tests/integration/test_blockworks_provider_integration.py
+++ b/tests/integration/test_blockworks_provider_integration.py
@@ -15,19 +15,19 @@ API_KEY = os.environ.get("BLOCKWORKS_API_KEY")
 
 
 @pytest.mark.integration
-def test_get_stablecoin_supply_live_api() -> None:
+def test_get_stablecoin_total_supply_live_api() -> None:
     """Calls Blockworks API directly and validates response mapping."""
     if not API_KEY:
         pytest.skip("Set BLOCKWORKS_API_KEY to run live Blockworks integration tests.")
 
     provider = Blockworks(api_key=API_KEY)
     metric = provider.get_metric(
-        metric="stablecoin_supply",
+        metric="stablecoin_total_supply",
         date="2025-01-01",
         chain="solana",
     )
 
     assert metric is not None
     assert isinstance(metric, Stablecoin)
-    assert metric.metric_type == StablecoinMetricType.SUPPLY
+    assert metric.metric_type == StablecoinMetricType.TOTAL_SUPPLY
     assert metric.value >= 0

--- a/tests/integration/test_defillama_provider_integration.py
+++ b/tests/integration/test_defillama_provider_integration.py
@@ -15,19 +15,19 @@ API_KEY = os.environ.get("DEFILLAMA_API_KEY")
 
 
 @pytest.mark.integration
-def test_get_stablecoin_supply_live_api() -> None:
+def test_get_stablecoin_circulating_supply_live_api() -> None:
     """Calls DefiLlama API directly and validates response mapping."""
     if not API_KEY:
         pytest.skip("Set DEFILLAMA_API_KEY to run live DefiLlama integration tests.")
 
     provider = DefiLlama(api_key=API_KEY)
     metric = provider.get_metric(
-        metric="stablecoin_supply",
+        metric="stablecoin_circulating_supply",
         date="2025-01-01",
         chain="solana",
     )
 
     assert metric is not None
     assert isinstance(metric, Stablecoin)
-    assert metric.metric_type == StablecoinMetricType.SUPPLY
+    assert metric.metric_type == StablecoinMetricType.CIRCULATING_SUPPLY
     assert metric.value >= 0

--- a/tests/integration/test_dune_provider_integration.py
+++ b/tests/integration/test_dune_provider_integration.py
@@ -15,19 +15,19 @@ API_KEY = os.environ.get("DUNE_API_KEY")
 
 
 @pytest.mark.integration
-def test_get_stablecoin_supply_live_api() -> None:
+def test_get_stablecoin_circulating_supply_live_api() -> None:
     """Calls Dune API directly and validates response mapping."""
     if not API_KEY:
         pytest.skip("Set DUNE_API_KEY to run live Dune integration tests.")
 
     provider = Dune(api_key=API_KEY)
     metric = provider.get_metric(
-        metric="stablecoin_supply",
+        metric="stablecoin_circulating_supply",
         date="2025-01-01",
         chain="solana",
     )
 
     assert metric is not None
     assert isinstance(metric, Stablecoin)
-    assert metric.metric_type == StablecoinMetricType.SUPPLY
+    assert metric.metric_type == StablecoinMetricType.CIRCULATING_SUPPLY
     assert metric.value >= 0

--- a/tests/integration/test_rwa_provider_integration.py
+++ b/tests/integration/test_rwa_provider_integration.py
@@ -15,19 +15,19 @@ API_KEY = os.environ.get("RWA_API_KEY")
 
 
 @pytest.mark.integration
-def test_get_stablecoin_supply_live_api() -> None:
+def test_get_stablecoin_total_supply_live_api() -> None:
     """Calls RWA API directly and validates response mapping."""
     if not API_KEY:
         pytest.skip("Set RWA_API_KEY to run live RWA integration tests.")
 
     provider = Rwa(api_key=API_KEY)
     metric = provider.get_metric(
-        metric="stablecoin_supply",
+        metric="stablecoin_total_supply",
         date="2025-01-01",
         chain="solana",
     )
 
     assert metric is not None
     assert isinstance(metric, Stablecoin)
-    assert metric.metric_type == StablecoinMetricType.SUPPLY
+    assert metric.metric_type == StablecoinMetricType.TOTAL_SUPPLY
     assert metric.value >= 0

--- a/tests/integration/test_token_terminal_provider_integration.py
+++ b/tests/integration/test_token_terminal_provider_integration.py
@@ -17,7 +17,7 @@ API_KEY = os.environ.get("TOKEN_TERMINAL_API_KEY")
 
 
 @pytest.mark.integration
-def test_get_stablecoin_supply_live_api() -> None:
+def test_get_stablecoin_total_supply_live_api() -> None:
     """Calls Token Terminal API directly and validates response mapping."""
     if not API_KEY:
         pytest.skip(
@@ -26,14 +26,14 @@ def test_get_stablecoin_supply_live_api() -> None:
 
     provider = TokenTerminal(api_key=API_KEY)
     metric = provider.get_metric(
-        metric="stablecoin_supply",
+        metric="stablecoin_total_supply",
         date="2025-01-01",
         chain="solana",
     )
 
     assert metric is not None
     assert isinstance(metric, Stablecoin)
-    assert metric.metric_type == StablecoinMetricType.SUPPLY
+    assert metric.metric_type == StablecoinMetricType.TOTAL_SUPPLY
     assert metric.value >= 0
 
 

--- a/tests/unit/test_allium_provider.py
+++ b/tests/unit/test_allium_provider.py
@@ -89,11 +89,11 @@ class TestAlliumPost:
 
 
 # ---------------------------------------------------------------------------
-# Allium — get_metric (stablecoin_supply)
+# Allium — get_metric (stablecoin_total_supply)
 # ---------------------------------------------------------------------------
 
 
-class TestGetMetricSupply:
+class TestGetMetricTotalSupply:
     def test_returns_stablecoin_metric(self, provider: Allium) -> None:
         rows = [{"date": "2026-01-01", "usd": 5_000_000_000.0}]
         sentinel_metric = object()
@@ -104,18 +104,18 @@ class TestGetMetricSupply:
                 Stablecoin, "from_metric_type", return_value=sentinel_metric
             ) as mock_factory,
         ):
-            result = provider.get_metric("stablecoin_supply", "2026-01-01", "solana")
+            result = provider.get_metric("stablecoin_total_supply", "2026-01-01", "solana")
 
         assert result is sentinel_metric
         mock_factory.assert_called_once()
         assert (
-            mock_factory.call_args.kwargs["metric_type"] == StablecoinMetricType.SUPPLY
+            mock_factory.call_args.kwargs["metric_type"] == StablecoinMetricType.TOTAL_SUPPLY
         )
         assert mock_factory.call_args.kwargs["value"] == 5_000_000_000.0
 
     def test_returns_none_on_empty_data(self, provider: Allium) -> None:
         with patch.object(provider._session, "post", side_effect=_mock_two_step([])):
-            result = provider.get_metric("stablecoin_supply", "2026-01-01", "solana")
+            result = provider.get_metric("stablecoin_total_supply", "2026-01-01", "solana")
 
         assert result is None
 
@@ -123,9 +123,38 @@ class TestGetMetricSupply:
         rows = [{"date": "2026-01-01", "usd": None}]
 
         with patch.object(provider._session, "post", side_effect=_mock_two_step(rows)):
-            result = provider.get_metric("stablecoin_supply", "2026-01-01", "solana")
+            result = provider.get_metric("stablecoin_total_supply", "2026-01-01", "solana")
 
         assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Allium — get_metric (stablecoin_circulating_supply)
+# ---------------------------------------------------------------------------
+
+
+class TestGetMetricCirculatingSupply:
+    def test_returns_stablecoin_metric(self, provider: Allium) -> None:
+        rows = [{"date": "2026-01-01", "usd": 4_600_000_000.0}]
+        sentinel_metric = object()
+
+        with (
+            patch.object(provider._session, "post", side_effect=_mock_two_step(rows)),
+            patch.object(
+                Stablecoin, "from_metric_type", return_value=sentinel_metric
+            ) as mock_factory,
+        ):
+            result = provider.get_metric(
+                "stablecoin_circulating_supply", "2026-01-01", "solana"
+            )
+
+        assert result is sentinel_metric
+        mock_factory.assert_called_once()
+        assert (
+            mock_factory.call_args.kwargs["metric_type"]
+            == StablecoinMetricType.CIRCULATING_SUPPLY
+        )
+        assert mock_factory.call_args.kwargs["value"] == 4_600_000_000.0
 
 
 # ---------------------------------------------------------------------------
@@ -220,7 +249,7 @@ class TestDateMatching:
         rows = [{"day": "2025-12-31", "total_supply_usd": 4_000_000_000.0}]
 
         with patch.object(provider._session, "post", side_effect=_mock_two_step(rows)):
-            result = provider.get_metric("stablecoin_supply", "2026-01-01", "solana")
+            result = provider.get_metric("stablecoin_total_supply", "2026-01-01", "solana")
 
         assert result is None
 
@@ -233,6 +262,6 @@ class TestDateMatching:
             patch.object(provider._session, "post", side_effect=_mock_two_step(rows)),
             patch.object(Stablecoin, "from_metric_type", return_value=sentinel_metric),
         ):
-            result = provider.get_metric("stablecoin_supply", "2026-01-01", "solana")
+            result = provider.get_metric("stablecoin_total_supply", "2026-01-01", "solana")
 
         assert result is sentinel_metric

--- a/tests/unit/test_artemis_provider.py
+++ b/tests/unit/test_artemis_provider.py
@@ -2,39 +2,42 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, patch  # noqa: F401
 
-from metrics.stablecoin import Stablecoin, StablecoinMetricType
-from providers.artemis import Artemis
+from metrics.stablecoin import Stablecoin, StablecoinMetricType  # noqa: F401
+from providers.artemis import Artemis  # noqa: F401
 
 
-def test_get_stablecoin_supply_returns_stablecoin_metric() -> None:
-    provider = Artemis(api_key="key")
-    mock_response = {
-        "data": {
-            "symbols": {
-                "solana": {
-                    "STABLECOIN_SUPPLY": [
-                        {"date": "2026-01-01", "val": 5_000_000_000.0},
-                    ]
-                }
-            }
-        }
-    }
-    mock_resp = MagicMock()
-    mock_resp.json.return_value = mock_response
-    mock_resp.raise_for_status = MagicMock()
-    sentinel_metric = object()
-
-    with (
-        patch.object(provider._session, "get", return_value=mock_resp),
-        patch.object(
-            Stablecoin, "from_metric_type", return_value=sentinel_metric
-        ) as mock_factory,
-    ):
-        result = provider.get_metric("stablecoin_supply", "2026-01-01", "solana")
-
-    assert result is sentinel_metric
-    mock_factory.assert_called_once()
-    assert mock_factory.call_args.kwargs["metric_type"] == StablecoinMetricType.SUPPLY
-    assert mock_factory.call_args.kwargs["value"] == 5_000_000_000.0
+# stablecoin_supply is intentionally out of Artemis's METRIC_MAP until they
+# confirm whether STABLECOIN_SUPPLY is circulating or total supply -- see
+# providers/artemis.py. Commented out rather than removed until that answer.
+# def test_get_stablecoin_supply_returns_stablecoin_metric() -> None:
+#     provider = Artemis(api_key="key")
+#     mock_response = {
+#         "data": {
+#             "symbols": {
+#                 "solana": {
+#                     "STABLECOIN_SUPPLY": [
+#                         {"date": "2026-01-01", "val": 5_000_000_000.0},
+#                     ]
+#                 }
+#             }
+#         }
+#     }
+#     mock_resp = MagicMock()
+#     mock_resp.json.return_value = mock_response
+#     mock_resp.raise_for_status = MagicMock()
+#     sentinel_metric = object()
+#
+#     with (
+#         patch.object(provider._session, "get", return_value=mock_resp),
+#         patch.object(
+#             Stablecoin, "from_metric_type", return_value=sentinel_metric
+#         ) as mock_factory,
+#     ):
+#         result = provider.get_metric("stablecoin_supply", "2026-01-01", "solana")
+#
+#     assert result is sentinel_metric
+#     mock_factory.assert_called_once()
+#     assert mock_factory.call_args.kwargs["metric_type"] == StablecoinMetricType.SUPPLY
+#     assert mock_factory.call_args.kwargs["value"] == 5_000_000_000.0

--- a/tests/unit/test_artemis_provider.py
+++ b/tests/unit/test_artemis_provider.py
@@ -2,42 +2,39 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch  # noqa: F401
+from unittest.mock import MagicMock, patch
 
-from metrics.stablecoin import Stablecoin, StablecoinMetricType  # noqa: F401
-from providers.artemis import Artemis  # noqa: F401
+from metrics.stablecoin import Stablecoin, StablecoinMetricType
+from providers.artemis import Artemis
 
 
-# stablecoin_supply is intentionally out of Artemis's METRIC_MAP until they
-# confirm whether STABLECOIN_SUPPLY is circulating or total supply -- see
-# providers/artemis.py. Commented out rather than removed until that answer.
-# def test_get_stablecoin_supply_returns_stablecoin_metric() -> None:
-#     provider = Artemis(api_key="key")
-#     mock_response = {
-#         "data": {
-#             "symbols": {
-#                 "solana": {
-#                     "STABLECOIN_SUPPLY": [
-#                         {"date": "2026-01-01", "val": 5_000_000_000.0},
-#                     ]
-#                 }
-#             }
-#         }
-#     }
-#     mock_resp = MagicMock()
-#     mock_resp.json.return_value = mock_response
-#     mock_resp.raise_for_status = MagicMock()
-#     sentinel_metric = object()
-#
-#     with (
-#         patch.object(provider._session, "get", return_value=mock_resp),
-#         patch.object(
-#             Stablecoin, "from_metric_type", return_value=sentinel_metric
-#         ) as mock_factory,
-#     ):
-#         result = provider.get_metric("stablecoin_supply", "2026-01-01", "solana")
-#
-#     assert result is sentinel_metric
-#     mock_factory.assert_called_once()
-#     assert mock_factory.call_args.kwargs["metric_type"] == StablecoinMetricType.SUPPLY
-#     assert mock_factory.call_args.kwargs["value"] == 5_000_000_000.0
+def test_get_stablecoin_circulating_supply_returns_stablecoin_metric() -> None:
+    provider = Artemis(api_key="key")
+    mock_response = {
+        "data": {
+            "symbols": {
+                "solana": {
+                    "STABLECOIN_SUPPLY": [
+                        {"date": "2026-01-01", "val": 5_000_000_000.0},
+                    ]
+                }
+            }
+        }
+    }
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = mock_response
+    mock_resp.raise_for_status = MagicMock()
+    sentinel_metric = object()
+
+    with (
+        patch.object(provider._session, "get", return_value=mock_resp),
+        patch.object(
+            Stablecoin, "from_metric_type", return_value=sentinel_metric
+        ) as mock_factory,
+    ):
+        result = provider.get_metric("stablecoin_circulating_supply", "2026-01-01", "solana")
+
+    assert result is sentinel_metric
+    mock_factory.assert_called_once()
+    assert mock_factory.call_args.kwargs["metric_type"] == StablecoinMetricType.CIRCULATING_SUPPLY
+    assert mock_factory.call_args.kwargs["value"] == 5_000_000_000.0

--- a/tests/unit/test_birdeye_provider.py
+++ b/tests/unit/test_birdeye_provider.py
@@ -168,9 +168,9 @@ def test_get_metric_stablecoin_defi() -> None:
     with patch.object(
         provider._session, "get", return_value=_make_mock_resp(_MARKET_HISTORY_RESPONSE)
     ):
-        result = provider.get_metric("stablecoin_supply", _DATE_7_7, "solana")
+        result = provider.get_metric("stablecoin_circulating_supply", _DATE_7_7, "solana")
         assert isinstance(result, Stablecoin)
-        assert result.metric_type == StablecoinMetricType.SUPPLY
+        assert result.metric_type == StablecoinMetricType.CIRCULATING_SUPPLY
         assert result.value == 14637051338.896027
         assert result.date == _date(_DATE_7_7)
 
@@ -192,7 +192,7 @@ def test_get_metric_stablecoin_defi_partial() -> None:
     with patch.object(
         provider._session, "get", return_value=_make_mock_resp(_MARKET_HISTORY_RESPONSE_PARTIAL)
     ):
-        result = provider.get_metric("stablecoin_supply", _DATE_7_8, "solana")
+        result = provider.get_metric("stablecoin_circulating_supply", _DATE_7_8, "solana")
         assert result is None
 
         result = provider.get_metric("defi_dex_volume", _DATE_7_8, "solana")
@@ -223,7 +223,7 @@ def test_fetch_rows_stablecoin_defi() -> None:
     with patch.object(
         provider._session, "get", return_value=_make_mock_resp(_MARKET_HISTORY_RESPONSE_MULTI_DAY)
     ):
-        rows = provider.fetch_rows("stablecoin_supply", _DATE_7_7, _DATE_7_8)
+        rows = provider.fetch_rows("stablecoin_circulating_supply", _DATE_7_7, _DATE_7_8)
         assert len(rows) == 1
         assert rows[0]["date"] == _DATE_7_7
         assert rows[0]["value"] == 14637051338.896027
@@ -279,7 +279,7 @@ def test_get_metric_failed() -> None:
         result = provider.get_metric("overview_sol_price", _DATE_7_7, "solana")
         assert result is None
 
-        result = provider.get_metric("stablecoin_supply", _DATE_7_7, "solana")
+        result = provider.get_metric("stablecoin_circulating_supply", _DATE_7_7, "solana")
         assert result is None
 
         result = provider.get_metric("defi_dex_volume", _DATE_7_7, "solana")

--- a/tests/unit/test_blockworks_provider.py
+++ b/tests/unit/test_blockworks_provider.py
@@ -8,7 +8,7 @@ from metrics.stablecoin import Stablecoin, StablecoinMetricType
 from providers.blockworks import Blockworks
 
 
-def test_get_stablecoin_supply_returns_stablecoin_metric() -> None:
+def test_get_stablecoin_total_supply_returns_stablecoin_metric() -> None:
     provider = Blockworks(api_key="key")
     mock_response = {
         "solana": [
@@ -26,9 +26,9 @@ def test_get_stablecoin_supply_returns_stablecoin_metric() -> None:
             Stablecoin, "from_metric_type", return_value=sentinel_metric
         ) as mock_factory,
     ):
-        result = provider.get_metric("stablecoin_supply", "2026-01-01", "solana")
+        result = provider.get_metric("stablecoin_total_supply", "2026-01-01", "solana")
 
     assert result is sentinel_metric
     mock_factory.assert_called_once()
-    assert mock_factory.call_args.kwargs["metric_type"] == StablecoinMetricType.SUPPLY
+    assert mock_factory.call_args.kwargs["metric_type"] == StablecoinMetricType.TOTAL_SUPPLY
     assert mock_factory.call_args.kwargs["value"] == 5_000_000_000.0

--- a/tests/unit/test_defillama_provider.py
+++ b/tests/unit/test_defillama_provider.py
@@ -22,7 +22,7 @@ def _make_mock_resp(payload):
     return mock_resp
 
 
-def test_get_stablecoin_supply_returns_stablecoin_metric() -> None:
+def test_get_stablecoin_circulating_supply_returns_stablecoin_metric() -> None:
     provider = DefiLlama()
     sentinel_metric = object()
 
@@ -32,11 +32,11 @@ def test_get_stablecoin_supply_returns_stablecoin_metric() -> None:
             Stablecoin, "from_metric_type", return_value=sentinel_metric
         ) as mock_factory,
     ):
-        result = provider.get_metric("stablecoin_supply", "2026-01-01", "solana")
+        result = provider.get_metric("stablecoin_circulating_supply", "2026-01-01", "solana")
 
     assert result is sentinel_metric
     mock_factory.assert_called_once()
-    assert mock_factory.call_args.kwargs["metric_type"] == StablecoinMetricType.SUPPLY
+    assert mock_factory.call_args.kwargs["metric_type"] == StablecoinMetricType.CIRCULATING_SUPPLY
     assert mock_factory.call_args.kwargs["value"] == 5_000_000_000.0
 
 
@@ -58,7 +58,7 @@ def test_fetch_rows_filters_by_date_range() -> None:
     ]
 
     with patch.object(provider._session, "get", return_value=_make_mock_resp(raw)):
-        rows = provider.fetch_rows("stablecoin_supply", "2025-01-01", "2026-06-01")
+        rows = provider.fetch_rows("stablecoin_circulating_supply", "2025-01-01", "2026-06-01")
 
     assert len(rows) == 1
     assert rows[0]["date"] == "2026-01-01"

--- a/tests/unit/test_dune_provider.py
+++ b/tests/unit/test_dune_provider.py
@@ -8,7 +8,7 @@ from metrics.stablecoin import Stablecoin, StablecoinMetricType
 from providers.dune import Dune
 
 
-def test_get_stablecoin_supply_returns_stablecoin_metric() -> None:
+def test_get_stablecoin_total_supply_returns_stablecoin_metric() -> None:
     provider = Dune(api_key="key", poll_interval=0, timeout=5)
 
     post_resp = MagicMock()
@@ -34,9 +34,48 @@ def test_get_stablecoin_supply_returns_stablecoin_metric() -> None:
             Stablecoin, "from_metric_type", return_value=sentinel_metric
         ) as mock_factory,
     ):
-        result = provider.get_metric("stablecoin_supply", "2026-01-01", "solana")
+        result = provider.get_metric("stablecoin_total_supply", "2026-01-01", "solana")
 
     assert result is sentinel_metric
     mock_factory.assert_called_once()
-    assert mock_factory.call_args.kwargs["metric_type"] == StablecoinMetricType.SUPPLY
+    assert mock_factory.call_args.kwargs["metric_type"] == StablecoinMetricType.TOTAL_SUPPLY
     assert mock_factory.call_args.kwargs["value"] == 5_000_000_000.0
+
+
+def test_get_stablecoin_circulating_supply_returns_stablecoin_metric() -> None:
+    provider = Dune(api_key="key", poll_interval=0, timeout=5)
+
+    post_resp = MagicMock()
+    post_resp.raise_for_status = MagicMock()
+    post_resp.json.return_value = {"execution_id": "exec-1"}
+
+    status_resp = MagicMock()
+    status_resp.raise_for_status = MagicMock()
+    status_resp.json.return_value = {"state": "QUERY_STATE_COMPLETED"}
+
+    results_resp = MagicMock()
+    results_resp.raise_for_status = MagicMock()
+    results_resp.json.return_value = {
+        "result": {
+            "rows": [{"day": "2026-01-01", "circulating_supply_usd": 4_600_000_000.0}]
+        }
+    }
+
+    sentinel_metric = object()
+
+    with (
+        patch.object(provider._session, "post", return_value=post_resp),
+        patch.object(provider._session, "get", side_effect=[status_resp, results_resp]),
+        patch.object(
+            Stablecoin, "from_metric_type", return_value=sentinel_metric
+        ) as mock_factory,
+    ):
+        result = provider.get_metric("stablecoin_circulating_supply", "2026-01-01", "solana")
+
+    assert result is sentinel_metric
+    mock_factory.assert_called_once()
+    assert (
+        mock_factory.call_args.kwargs["metric_type"]
+        == StablecoinMetricType.CIRCULATING_SUPPLY
+    )
+    assert mock_factory.call_args.kwargs["value"] == 4_600_000_000.0

--- a/tests/unit/test_rwa_provider.py
+++ b/tests/unit/test_rwa_provider.py
@@ -8,7 +8,7 @@ from metrics.stablecoin import Stablecoin, StablecoinMetricType
 from providers.rwa import Rwa
 
 
-def test_get_stablecoin_supply_returns_stablecoin_metric() -> None:
+def test_get_stablecoin_total_supply_returns_stablecoin_metric() -> None:
     provider = Rwa(api_key="key")
     mock_response = {
         "results": [
@@ -30,9 +30,9 @@ def test_get_stablecoin_supply_returns_stablecoin_metric() -> None:
             Stablecoin, "from_metric_type", return_value=sentinel_metric
         ) as mock_factory,
     ):
-        result = provider.get_metric("stablecoin_supply", "2026-01-01", "solana")
+        result = provider.get_metric("stablecoin_total_supply", "2026-01-01", "solana")
 
     assert result is sentinel_metric
     mock_factory.assert_called_once()
-    assert mock_factory.call_args.kwargs["metric_type"] == StablecoinMetricType.SUPPLY
+    assert mock_factory.call_args.kwargs["metric_type"] == StablecoinMetricType.TOTAL_SUPPLY
     assert mock_factory.call_args.kwargs["value"] == 5_000_000_000.0

--- a/tests/unit/test_token_terminal_provider.py
+++ b/tests/unit/test_token_terminal_provider.py
@@ -12,7 +12,7 @@ from metrics.stablecoin import Stablecoin, StablecoinMetricType
 from providers.token_terminal import TokenTerminal
 
 
-def test_get_stablecoin_supply_sums_native_and_bridged() -> None:
+def test_get_stablecoin_total_supply_sums_native_and_bridged() -> None:
     provider = TokenTerminal(api_key="test-token-terminal-key")
     mock_response = [
         {
@@ -32,16 +32,16 @@ def test_get_stablecoin_supply_sums_native_and_bridged() -> None:
             Stablecoin, "from_metric_type", return_value=sentinel_metric
         ) as mock_factory,
     ):
-        result = provider.get_metric("stablecoin_supply", "2026-01-01", "solana")
+        result = provider.get_metric("stablecoin_total_supply", "2026-01-01", "solana")
 
     assert result is sentinel_metric
     mock_factory.assert_called_once()
-    assert mock_factory.call_args.kwargs["metric_type"] == StablecoinMetricType.SUPPLY
+    assert mock_factory.call_args.kwargs["metric_type"] == StablecoinMetricType.TOTAL_SUPPLY
     # Total supply = native issuance + bridged-in supply.
     assert mock_factory.call_args.kwargs["value"] == pytest.approx(13_487_267_570.64)
 
 
-def test_get_stablecoin_supply_tolerates_missing_bridged_value() -> None:
+def test_get_stablecoin_total_supply_tolerates_missing_bridged_value() -> None:
     provider = TokenTerminal(api_key="test-token-terminal-key")
     mock_response = [
         {
@@ -60,7 +60,7 @@ def test_get_stablecoin_supply_tolerates_missing_bridged_value() -> None:
             Stablecoin, "from_metric_type", return_value=sentinel_metric
         ) as mock_factory,
     ):
-        result = provider.get_metric("stablecoin_supply", "2026-01-01", "solana")
+        result = provider.get_metric("stablecoin_total_supply", "2026-01-01", "solana")
 
     assert result is sentinel_metric
     assert mock_factory.call_args.kwargs["value"] == 10_987_267_570.64

--- a/tests/unit/test_topledger_provider.py
+++ b/tests/unit/test_topledger_provider.py
@@ -314,12 +314,12 @@ _STABLECOIN_ROWS = [
 ]
 
 
-def test_fetch_rows_stablecoin_supply() -> None:
+def test_fetch_rows_stablecoin_circulating_supply() -> None:
     provider = _make_provider()
     with patch.object(
         provider._session, "post", return_value=_immediate_result_resp(_STABLECOIN_ROWS)
     ):
-        rows = provider.fetch_rows("stablecoin_supply", _START, "2026-07-02")
+        rows = provider.fetch_rows("stablecoin_circulating_supply", _START, "2026-07-02")
 
     assert len(rows) == 2
     assert rows[0] == {"date": "2026-07-01", "value": pytest.approx(12_500_000_000.0)}
@@ -337,12 +337,12 @@ def test_fetch_rows_stablecoin_count() -> None:
 
 
 def test_stablecoin_metrics_share_one_query_call() -> None:
-    """stablecoin_supply and stablecoin_count both use query 15090 — one POST."""
+    """stablecoin_circulating_supply and stablecoin_count both use query 15090 — one POST."""
     provider = _make_provider()
     mock_post = MagicMock(return_value=_immediate_result_resp(_STABLECOIN_ROWS))
 
     with patch.object(provider._session, "post", mock_post):
-        provider.fetch_rows("stablecoin_supply", _START, "2026-07-02")
+        provider.fetch_rows("stablecoin_circulating_supply", _START, "2026-07-02")
         provider.fetch_rows("stablecoin_count", _START, "2026-07-02")
 
     assert mock_post.call_count == 1
@@ -353,10 +353,10 @@ def test_get_metric_returns_stablecoin_model() -> None:
     with patch.object(
         provider._session, "post", return_value=_immediate_result_resp(_STABLECOIN_ROWS)
     ):
-        result = provider.get_metric("stablecoin_supply", _START, "solana")
+        result = provider.get_metric("stablecoin_circulating_supply", _START, "solana")
 
     assert isinstance(result, Stablecoin)
-    assert result.metric_type == StablecoinMetricType.SUPPLY
+    assert result.metric_type == StablecoinMetricType.CIRCULATING_SUPPLY
     assert result.value == pytest.approx(12_500_000_000.0)
     assert result.date == datetime.date.fromisoformat(_START)
 


### PR DESCRIPTION
## Updates 
- Split Stablecoin Supply into Total and  Circulating Supply 

Tested on Databricks. Waiting for a response from Artemis to confirm that their stable supply is Total or Circulating.

<img width="662" height="539" alt="image" src="https://github.com/user-attachments/assets/b1cb2fc1-78d9-4ff7-abf9-da0cdb1f12c3" />

<img width="662" height="539" alt="image" src="https://github.com/user-attachments/assets/6b7ef0f7-d35a-44fd-9895-95b1d498c445" />
