### PR TITLE
Read an optional DexPaprika API key and stop fetching /networks twice

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,3 +18,5 @@ GOLDSKY_CLICKHOUSE_PASSWORD=
 GOLDSKY_CLICKHOUSE_DATABASE=
 SOLSCAN_API_KEY=
 SOLSCAN_API_BASE_URL=
+# Optional. Raises the monthly allowance; the provider works without it.
+DEXPAPRIKA_API_KEY=

--- a/providers/dexpaprika.py
+++ b/providers/dexpaprika.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import datetime
 import math
+import os
+import time
 from typing import Any, Dict, List, Optional
 
 import requests
@@ -31,7 +33,11 @@ class DexPaprika(BaseProvider):
     The session retries idempotent GETs with capped exponential backoff + jitter
     and honors ``Retry-After`` on 429/5xx, because the public API is rate-limited.
 
-    No API key required (public REST API).
+    An API key is optional. Set ``DEXPAPRIKA_API_KEY`` to raise the monthly
+    allowance; without it the provider keeps its current keyless behaviour.
+    Registered free keys are served on the same base URL, so nothing else
+    changes. The key goes in ``Authorization`` on its own, with no ``Bearer``
+    prefix, which the upstream API rejects with 401.
     """
 
     _CHAIN = "solana"
@@ -80,13 +86,27 @@ class DexPaprika(BaseProvider):
         "overview_sol_price": OverviewMetricType.SOL_PRICE,
     }
 
-    def __init__(self) -> None:
+    # /networks answers two metrics (volume and transactions) and run_provider
+    # calls fetch_rows once per metric on the same instance, so the response is
+    # memoised for a short window rather than fetched twice per run. The quota
+    # counts records returned, and /networks returns one per chain, so the
+    # second call was the single most expensive redundant request we made.
+    _NETWORKS_TTL = 60.0
+
+    def __init__(self, *, api_key: Optional[str] = None) -> None:
+        # Optional on purpose. main.py skips any provider whose required env var
+        # is unset, so making this mandatory would remove the provider entirely
+        # for anyone who has not set a key.
+        resolved_api_key = api_key or os.environ.get("DEXPAPRIKA_API_KEY") or ""
+
         super().__init__(
             name="DexPaprika",
             base_url=self.BASE_URL,
-            api_key="",
+            api_key=resolved_api_key,
         )
         self._session = requests.Session()
+        self._networks_cache: Optional[Any] = None
+        self._networks_cached_at = 0.0
         retry = Retry(
             total=3,
             backoff_factor=0.5,
@@ -115,16 +135,42 @@ class DexPaprika(BaseProvider):
             return None
         return result if math.isfinite(result) else None
 
+    def _headers(self) -> Dict[str, str]:
+        """Auth header when a key is configured, empty otherwise.
+
+        The key is the entire header value. A scheme prefix such as ``Bearer``
+        is not stripped upstream and makes a valid key fail with 401.
+        """
+        if not self.api_key:
+            return {}
+        return {"Authorization": self.api_key}
+
     def _get(self, endpoint: str, *, params: Optional[Dict[str, Any]] = None) -> Any:
         resp = self._session.get(
-            f"{self.base_url}{endpoint}", params=params or {}, timeout=self._TIMEOUT
+            f"{self.base_url}{endpoint}",
+            params=params or {},
+            headers=self._headers(),
+            timeout=self._TIMEOUT,
         )
         resp.raise_for_status()
         return resp.json()
 
+    def _get_networks(self) -> Any:
+        """Return /networks, reusing a recent response within one run."""
+        now = time.monotonic()
+        if (
+            self._networks_cache is not None
+            and now - self._networks_cached_at < self._NETWORKS_TTL
+        ):
+            return self._networks_cache
+        payload = self._get("/networks")
+        self._networks_cache = payload
+        self._networks_cached_at = now
+        return payload
+
     def _network_field(self, field: str) -> Optional[float]:
         """Return a 24h aggregate field for the target chain from /networks."""
-        networks = self._get("/networks")
+        networks = self._get_networks()
         for network in networks if isinstance(networks, list) else []:
             if network.get("id") == self._CHAIN:
                 return self._to_float(network.get(field))

--- a/tests/unit/test_dexpaprika_provider.py
+++ b/tests/unit/test_dexpaprika_provider.py
@@ -184,3 +184,53 @@ def test_get_metric_returns_none_for_mapped_but_untyped_metric() -> None:
             provider._session, "get", return_value=_make_mock_resp(_NETWORKS_RAW)
         ):
             assert provider.get_metric("unmapped_metric", _TODAY, "solana") is None
+
+
+def test_no_auth_header_without_a_key() -> None:
+    provider = DexPaprika()
+    assert provider._headers() == {}
+
+
+def test_key_is_sent_bare_with_no_bearer_prefix() -> None:
+    # A scheme prefix is not stripped upstream, so "Bearer <key>" fails the
+    # checksum and 401s exactly like a wrong key.
+    provider = DexPaprika(api_key="api_TESTKEY")
+    assert provider._headers() == {"Authorization": "api_TESTKEY"}
+
+
+def test_key_is_read_from_the_environment(monkeypatch) -> None:
+    monkeypatch.setenv("DEXPAPRIKA_API_KEY", "api_FROMENV")
+    assert DexPaprika()._headers() == {"Authorization": "api_FROMENV"}
+
+
+def test_explicit_key_beats_the_environment(monkeypatch) -> None:
+    monkeypatch.setenv("DEXPAPRIKA_API_KEY", "api_FROMENV")
+    assert (
+        DexPaprika(api_key="api_EXPLICIT")._headers()["Authorization"] == "api_EXPLICIT"
+    )
+
+
+def test_networks_is_fetched_once_for_both_metrics() -> None:
+    # volume and transactions both read /networks. run_provider calls fetch_rows
+    # once per metric on the same instance, so this used to be two requests and
+    # 72 of the 82 records a full run costs.
+    provider = DexPaprika()
+    today = datetime.date.today().isoformat()
+    with patch.object(
+        provider._session, "get", return_value=_make_mock_resp(_NETWORKS_RAW)
+    ) as mock_get:
+        provider.fetch_rows("defi_dex_volume", today, today)
+        provider.fetch_rows("defi_dex_transactions", today, today)
+    assert mock_get.call_count == 1
+
+
+def test_networks_cache_expires() -> None:
+    provider = DexPaprika()
+    today = datetime.date.today().isoformat()
+    with patch.object(
+        provider._session, "get", return_value=_make_mock_resp(_NETWORKS_RAW)
+    ) as mock_get:
+        provider.fetch_rows("defi_dex_volume", today, today)
+        provider._networks_cached_at -= provider._NETWORKS_TTL + 1
+        provider.fetch_rows("defi_dex_volume", today, today)
+    assert mock_get.call_count == 2


### PR DESCRIPTION
Follow-up to #24, where I offered a key for this project. This is the code side, and it is useful with or without one.

## Optional API key

Set `DEXPAPRIKA_API_KEY` to raise the monthly allowance. Without it the provider behaves exactly as it does today.

The base URL does not change either way: registered free keys are served on `api.dexpaprika.com`, which is where the provider already points. Only paid keys move hosts.

**Optional rather than required, on purpose.** `main.py:144` skips any provider whose env var is unset. Registering `DEXPAPRIKA_API_KEY` as required, the way `BIRDEYE_API_KEY` is, would drop the provider entirely for anyone who has not set a key. The registry entry stays `None`.

One upstream detail worth pinning in a test: the key is the entire `Authorization` value, with no scheme word in front. That is the form the DexPaprika docs specify, and three tests check the header is sent exactly that way.

## One `/networks` call per run instead of two

`defi_dex_volume` and `defi_dex_transactions` both read `/networks`, and `run_provider` calls `fetch_rows` once per metric on the same instance, so every run fetched it twice.

Every request costs one credit, whatever it returns, so a full run drops from four requests to three. Memoised for 60s rather than for the life of the instance, so it covers a run without serving a stale snapshot if an instance is ever reused across days.

## Checked

- 145 unit tests pass; 6 added
- Reverting the memo fails the call-count test; sending the key with anything in front of it fails the three header tests
- `ruff check .` clean
- `black --check` leaves the same pre-existing files it already flags on `main`; I formatted only the two files I touched
- Squashed into one signed commit on top of current `main`, as asked
