### PR TITLE
Cast Birdeye Values to float in fetch_rows

### DIFF
--- a/providers/birdeye.py
+++ b/providers/birdeye.py
@@ -155,7 +155,7 @@ class Birdeye(BaseProvider):
                             result.append(
                                 {
                                     "date": self._timestamp_to_date(timestamp),
-                                    "value": record["value"],
+                                    "value": float(record["value"]),
                                 }
                             )
 
@@ -188,7 +188,7 @@ class Birdeye(BaseProvider):
                                 result.append(
                                     {
                                         "date": self._timestamp_to_date(timestamp),
-                                        "value": record[metric_field],
+                                        "value": float(record[metric_field]),
                                     }
                                 ) 
                         if not data.get("has_more", False):

--- a/tests/unit/test_birdeye_provider.py
+++ b/tests/unit/test_birdeye_provider.py
@@ -234,6 +234,11 @@ def test_fetch_rows_stablecoin_defi() -> None:
         assert rows[0]["value"] == 12066695086.76048
         assert rows[1]["date"] == _DATE_7_8
         assert rows[1]["value"] == 1234567890
+        # The API returns a whole number (no decimal point) for this day, which
+        # json-decodes as an int -- must still be cast to float so a mixed
+        # int/float "value" column across the date range doesn't break Spark's
+        # createDataFrame schema inference downstream.
+        assert isinstance(rows[1]["value"], float)
 
         rows = provider.fetch_rows("defi_dex_transactions", _DATE_7_7, _DATE_7_8)
         assert len(rows) == 1


### PR DESCRIPTION
## UPdates 
- Fixed `PySparkTypeError: [CANNOT_MERGE_TYPE] Can not merge type `LongType` and `DoubleType`.` by float

Tested on Databricks and fetch_all worked fine without the error.