### PR TITLE
Fix Integration Test

### DIFF
--- a/tests/integration/test_birdeye_provider_integration.py
+++ b/tests/integration/test_birdeye_provider_integration.py
@@ -15,6 +15,8 @@ from providers.birdeye import Birdeye
 load_dotenv()
 API_KEY = os.environ.get("BIRDEYE_API_KEY")
 
+pytestmark = pytest.mark.skipif(not API_KEY, reason="BIRDEYE_API_KEY not set")
+
 _TODAY = datetime.date.today()
 _TODAY_STR = _TODAY.isoformat()
 

--- a/tests/integration/test_topledger_provider_integration.py
+++ b/tests/integration/test_topledger_provider_integration.py
@@ -3,11 +3,18 @@
 from __future__ import annotations
 
 import datetime
+import os
 
 import pytest
+from dotenv import load_dotenv
 
 from metrics.overview import Overview, OverviewMetricType
 from providers.topledger import TopLedger
+
+load_dotenv()
+API_KEY = os.environ.get("TOPLEDGER_API_KEY")
+
+pytestmark = pytest.mark.skipif(not API_KEY, reason="TOPLEDGER_API_KEY not set")
 
 
 @pytest.mark.integration

--- a/tests/integration/test_uniblock_provider_integration.py
+++ b/tests/integration/test_uniblock_provider_integration.py
@@ -16,6 +16,8 @@ load_dotenv()
 API_KEY = os.environ.get("UNIBLOCK_API_KEY")
 _TODAY = datetime.date.today().isoformat()
 
+pytestmark = pytest.mark.skipif(not API_KEY, reason="UNIBLOCK_API_KEY not set")
+
 
 @pytest.mark.integration
 def test_fetch_sol_price_series_live_api() -> None:


### PR DESCRIPTION
## Updates 

- Added skip when API_KEYS are not set in `.env` for the 3 data providers integration tests