### PR TITLE
Fix Bitquery DEX volume outliers and DEX transaction counting

### DIFF
--- a/providers/bitquery.py
+++ b/providers/bitquery.py
@@ -35,7 +35,6 @@ from metrics.overview import Overview, OverviewMetricType
 from providers.base import BaseProvider
 
 TRADES_DOCS_URL = "https://docs.bitquery.io/docs/trading/crypto-trades-api/trades-api/"
-PAIRS_DOCS_URL = "https://docs.bitquery.io/docs/trading/crypto-price-api/pairs/"
 TOKENS_DOCS_URL = "https://docs.bitquery.io/docs/trading/crypto-price-api/tokens/"
 
 # Wrapped SOL mint; the Price Index prices native SOL via the wSOL token.
@@ -51,15 +50,25 @@ _TRADES_QUERY = """
   ) {{ Block {{ Date }} value: {aggregate} }} }} }}
 """
 
-_PAIRS_VOLUME_QUERY = """
-{{ Trading {{ Pairs(
+# Per-trade USD bounds applied to the volume metric. The lower bound drops
+# dust/decimal-noise trades; the upper bound drops trades whose quote-leg USD
+# value is implausibly large (e.g. wash trades in self-paired junk-token pools
+# that the Price Index misprices by orders of magnitude). Validated against
+# other daily Solana DEX volume sources: the band keeps totals within a few
+# percent of them, while a single unfiltered pool can otherwise inflate a day
+# from ~$7B to hundreds of trillions.
+_VOLUME_MIN_TRADE_USD = 1
+_VOLUME_MAX_TRADE_USD = 10_000_000
+
+_TRADES_VOLUME_QUERY = """
+{{ Trading {{ Trades(
     where: {{
-      Market: {{NetworkBid: {{is: "bid:solana"}}}},
-      Interval: {{Time: {{Duration: {{eq: 3600}}}}}},
-      Block: {{Time: {{since: "{since}", till: "{till}"}}}}
+      Block: {{Time: {{since: "{since}", till: "{till}"}}}},
+      Pair: {{Market: {{NetworkBid: {{is: "bid:solana"}}}}}},
+      AmountsInUsd: {{Quote: {{gt: {min_trade_usd}, lt: {max_trade_usd}}}}}
     }}
     orderBy: {{ascending: Block_Date}}
-  ) {{ Block {{ Date }} value: sum(of: Volume_Usd) }} }} }}
+  ) {{ Block {{ Date }} value: sum(of: AmountsInUsd_Quote) }} }} }}
 """
 
 _TOKENS_PRICE_QUERY = """
@@ -84,25 +93,29 @@ class Bitquery(BaseProvider):
 
     METRIC_MAP: Dict[str, Dict[str, Any]] = {
         "defi_dex_volume": {
-            "cube": "Pairs",
-            "query": _PAIRS_VOLUME_QUERY,
+            "cube": "Trades",
+            "query": _TRADES_VOLUME_QUERY,
             "cast": float,
             "methodology": (
-                "Daily USD volume summed across all DEX trading pairs indexed on "
-                "Solana, from the pre-aggregated Trading.Pairs cube. Covers every "
-                "indexed swap; MEV and outlier trades are filtered by the Bitquery "
-                "Price Index before aggregation."
+                "Daily USD DEX volume on Solana: quote-leg USD amounts "
+                "(AmountsInUsd.Quote) summed per day over swap-level rows in the "
+                "Trading.Trades cube, keeping only trades between "
+                f"${_VOLUME_MIN_TRADE_USD} and ${_VOLUME_MAX_TRADE_USD:,} to "
+                "exclude dust and mispriced outlier trades (e.g. wash trading in "
+                "self-paired junk-token pools)."
             ),
-            "methodology_url": PAIRS_DOCS_URL,
+            "methodology_url": TRADES_DOCS_URL,
         },
         "defi_dex_transactions": {
             "cube": "Trades",
             "query": _TRADES_QUERY,
-            "aggregate": "count",
+            "aggregate": "count(distinct: TransactionHeader_Hash)",
             "cast": int,
             "methodology": (
-                "Number of DEX swaps per day on Solana from the Trading.Trades "
-                "cube (one row per swap, MEV/outlier-filtered)."
+                "Number of distinct transactions containing at least one DEX "
+                "swap per day on Solana, from the Trading.Trades cube. Counting "
+                "distinct transaction hashes (rather than swap rows) keeps "
+                "multi-hop routed trades from being counted once per hop."
             ),
             "methodology_url": TRADES_DOCS_URL,
         },
@@ -231,6 +244,8 @@ class Bitquery(BaseProvider):
             till=till,
             aggregate=config.get("aggregate", ""),
             mint=_WSOL_MINT,
+            min_trade_usd=_VOLUME_MIN_TRADE_USD,
+            max_trade_usd=_VOLUME_MAX_TRADE_USD,
         )
         data = self._post(query)
         rows = (data.get("Trading") or {}).get(config["cube"]) or []

--- a/tests/unit/test_bitquery_provider.py
+++ b/tests/unit/test_bitquery_provider.py
@@ -28,10 +28,10 @@ _TRADES_RESPONSE = {
     }
 }
 
-_PAIRS_RESPONSE = {
+_VOLUME_RESPONSE = {
     "data": {
         "Trading": {
-            "Pairs": [
+            "Trades": [
                 {"Block": {"Date": "2026-08-10"}, "value": "5856833485.5"},
                 {"Block": {"Date": "2026-08-11"}, "value": "5735027474.1"},
                 {"Block": {"Date": "2026-08-12"}, "value": "4962759327.9"},
@@ -83,7 +83,7 @@ def test_fetch_rows_trades_counts_are_ints_and_range_filtered() -> None:
 
 
 def test_fetch_rows_volume_parses_string_floats() -> None:
-    provider = _provider_with_response(_PAIRS_RESPONSE)
+    provider = _provider_with_response(_VOLUME_RESPONSE)
     rows = provider.fetch_rows("defi_dex_volume", _START, _END)
 
     assert len(rows) == 3
@@ -124,8 +124,17 @@ def test_query_uses_inclusive_day_bounds() -> None:
     assert "bid:solana" in query
 
 
+def test_volume_query_applies_per_trade_usd_band() -> None:
+    provider = _provider_with_response(_VOLUME_RESPONSE)
+    provider.fetch_rows("defi_dex_volume", _START, _END)
+
+    query = provider._session.post.call_args.kwargs["json"]["query"]
+    assert "AmountsInUsd: {Quote: {gt: 1, lt: 10000000}}" in query
+    assert "sum(of: AmountsInUsd_Quote)" in query
+
+
 def test_get_metric_defi() -> None:
-    provider = _provider_with_response(_PAIRS_RESPONSE)
+    provider = _provider_with_response(_VOLUME_RESPONSE)
     metric = provider.get_metric("defi_dex_volume", "2026-08-11", "solana")
 
     assert isinstance(metric, Defi)


### PR DESCRIPTION
Fixes #35. 

## Root cause
The DEX volume metric summed pre-aggregated pair volume, which cannot exclude
individual mispriced trades. A self-paired junk-token pool (ZCAT/ZCAT) produced
wash trades valued at ~$18T each, inflating daily volume from ~$7B to hundreds
of trillions on Sep 3–7.

## Changes
- `defi_dex_volume` now sums per-trade quote-leg USD amounts from the swap-level
  Trades cube, keeping only trades between $1 and $10M. The lower bound drops
  dust/decimal noise; the upper bound drops mispriced outliers.
- `defi_dex_transactions` now counts distinct transaction hashes instead of swap
  rows, so multi-hop routed trades are no longer counted once per hop.

## Validation (vs other providers on solana.com/data)
- Volume: all 30 days land within a few percent of Allium, between Allium and
  Birdeye (e.g. Sep 5: $6.68B vs Allium $6.75B, Birdeye $8.66B — previously $424T).
- Transactions: within 1–3% of Allium (e.g. Sep 5: 26.2M vs Allium 27.0M).
- SOL price: matches Uniblock to the cent across the window.
- Unit tests 11/11 pass; live integration tests 3/3 pass.