### PR TITLE
fix: treat null active_stake as zero in validators app provider

### DIFF
--- a/providers/validators_app.py
+++ b/providers/validators_app.py
@@ -111,7 +111,7 @@ class ValidatorsApp(BaseProvider):
             ]
             agg = config["validators_aggregate"]
             if agg == "sum_stake":
-                value = sum(v.get("active_stake", 0) for v in active) / 1e9
+                value = sum(v.get("active_stake") or 0 for v in active) / 1e9
             elif agg == "count":
                 value = float(len(active))
             else:  # top_3_asn_share
@@ -119,8 +119,8 @@ class ValidatorsApp(BaseProvider):
                 for v in active:
                     asn = v.get("autonomous_system_number")
                     if asn:
-                        asn_stake[asn] = asn_stake.get(asn, 0) + v.get(
-                            "active_stake", 0
+                        asn_stake[asn] = asn_stake.get(asn, 0) + (
+                            v.get("active_stake") or 0
                         )
                 sorted_stakes = sorted(asn_stake.values(), reverse=True)
                 total = sum(sorted_stakes)

--- a/tests/unit/test_validators_app_provider.py
+++ b/tests/unit/test_validators_app_provider.py
@@ -123,6 +123,26 @@ def test_fetch_rows_total_stake_sums_active_lamports_to_sol() -> None:
     assert rows[0]["date"] == TODAY
 
 
+def test_fetch_rows_total_stake_treats_null_active_stake_as_zero() -> None:
+    provider = _provider()
+    with_null = _VALIDATORS_RAW[:2] + [
+        {
+            "is_active": True,
+            "delinquent": False,
+            "active_stake": None,
+            "autonomous_system_number": 777,
+        }
+    ]
+    with (
+        patch.object(provider._session, "get", return_value=_mock_resp(with_null)),
+        _patch_today(),
+    ):
+        rows = provider.fetch_rows("network_total_stake", TODAY, TODAY)
+
+    # 1_000 + 500 + 0 (null) = 1_500 SOL
+    assert rows[0]["value"] == pytest.approx(1_500.0)
+
+
 def test_fetch_rows_total_stake_excludes_inactive_validators() -> None:
     provider = _provider()
     all_inactive = [


### PR DESCRIPTION
Related: DAT-396

## Root cause
Job `Validators_App_Retrieval` failed with:
```
TypeError: unsupported operand type(s) for +: 'int' and 'NoneType'
```
Validators.app returned at least one active validator with `active_stake: null`.
`dict.get(key, default)` only falls back to `default` when the key is missing,
not when it's present with value `None`, so `sum(v.get("active_stake", 0) for v
in active)` evaluated to `None` for that entry and the sum blew up.

## Changes
- `providers/validators_app.py`: use `v.get("active_stake") or 0` instead of
  `v.get("active_stake", 0)` in both the `sum_stake` and `top_3_asn_share`
  aggregates, so an explicit `null` is coerced to `0`.
- `tests/unit/test_validators_app_provider.py`: added regression tests for
  both aggregates with a null `active_stake` entry mixed into the validator set.

## Validation
- Unit tests: 126/126 pass (`pytest -q -m "not integration"`), including the
  2 new regression tests.