### PR TITLE
Filter Bitquery Trades queries by Block.Date and use approximate uniq for transaction counts

### DIFF
--- a/providers/bitquery.py
+++ b/providers/bitquery.py
@@ -40,10 +40,13 @@ TOKENS_DOCS_URL = "https://docs.bitquery.io/docs/trading/crypto-price-api/tokens
 # Wrapped SOL mint; the Price Index prices native SOL via the wSOL token.
 _WSOL_MINT = "So11111111111111111111111111111111111111112"
 
+# Trades queries filter on Block.Date (inclusive of both bounds) rather than
+# Block.Time: the date filter prunes the scan far better on the backend, which
+# keeps multi-day aggregations comfortably inside the server's query deadline.
 _TRADES_QUERY = """
 {{ Trading {{ Trades(
     where: {{
-      Block: {{Time: {{since: "{since}", till: "{till}"}}}},
+      Block: {{Date: {{since: "{start_date}", till: "{end_date}"}}}},
       Pair: {{Market: {{NetworkBid: {{is: "bid:solana"}}}}}}
     }}
     orderBy: {{ascending: Block_Date}}
@@ -63,7 +66,7 @@ _VOLUME_MAX_TRADE_USD = 10_000_000
 _TRADES_VOLUME_QUERY = """
 {{ Trading {{ Trades(
     where: {{
-      Block: {{Time: {{since: "{since}", till: "{till}"}}}},
+      Block: {{Date: {{since: "{start_date}", till: "{end_date}"}}}},
       Pair: {{Market: {{NetworkBid: {{is: "bid:solana"}}}}}},
       AmountsInUsd: {{Quote: {{gt: {min_trade_usd}, lt: {max_trade_usd}}}}}
     }}
@@ -109,13 +112,15 @@ class Bitquery(BaseProvider):
         "defi_dex_transactions": {
             "cube": "Trades",
             "query": _TRADES_QUERY,
-            "aggregate": "count(distinct: TransactionHeader_Hash)",
+            "aggregate": "uniq(of: TransactionHeader_Hash, method: approximate)",
             "cast": int,
             "methodology": (
                 "Number of distinct transactions containing at least one DEX "
                 "swap per day on Solana, from the Trading.Trades cube. Counting "
                 "distinct transaction hashes (rather than swap rows) keeps "
-                "multi-hop routed trades from being counted once per hop."
+                "multi-hop routed trades from being counted once per hop; the "
+                "approximate uniq (error well under 1%) avoids exact-distinct "
+                "query timeouts over multi-day windows."
             ),
             "methodology_url": TRADES_DOCS_URL,
         },
@@ -240,6 +245,10 @@ class Bitquery(BaseProvider):
 
         since, till = self._day_bounds(start_date, end_date)
         query = config["query"].format(
+            # Trades queries filter on Block.Date with both bounds inclusive;
+            # the Tokens price query still needs the [since, till) instants.
+            start_date=start_date,
+            end_date=end_date,
             since=since,
             till=till,
             aggregate=config.get("aggregate", ""),

--- a/tests/unit/test_bitquery_provider.py
+++ b/tests/unit/test_bitquery_provider.py
@@ -114,14 +114,30 @@ def test_fetch_rows_raises_on_graphql_errors() -> None:
         provider.fetch_rows("defi_dex_volume", _START, _END)
 
 
-def test_query_uses_inclusive_day_bounds() -> None:
+def test_trades_query_uses_inclusive_date_bounds() -> None:
     provider = _provider_with_response(_TRADES_RESPONSE)
     provider.fetch_rows("defi_dex_transactions", _START, _END)
 
     query = provider._session.post.call_args.kwargs["json"]["query"]
+    assert 'Block: {Date: {since: "2026-08-10", till: "2026-08-12"}}' in query
+    assert "bid:solana" in query
+
+
+def test_transactions_query_uses_approximate_uniq() -> None:
+    provider = _provider_with_response(_TRADES_RESPONSE)
+    provider.fetch_rows("defi_dex_transactions", _START, _END)
+
+    query = provider._session.post.call_args.kwargs["json"]["query"]
+    assert "uniq(of: TransactionHeader_Hash, method: approximate)" in query
+
+
+def test_price_query_uses_inclusive_day_instants() -> None:
+    provider = _provider_with_response(_TOKENS_RESPONSE)
+    provider.fetch_rows("overview_sol_price", _START, _END)
+
+    query = provider._session.post.call_args.kwargs["json"]["query"]
     assert '"2026-08-10T00:00:00Z"' in query
     assert '"2026-08-13T00:00:00Z"' in query  # end_date + 1 day
-    assert "bid:solana" in query
 
 
 def test_volume_query_applies_per_trade_usd_band() -> None:


### PR DESCRIPTION
Follow-up to #37. Makes the Bitquery provider's queries reliably fast; no
metric definitions change beyond a <0.2% approximation on transaction counts.

## Problem
The four Trades-cube metrics filtered on `Block.Time`, which the backend
cannot prune efficiently — a 7-day window took up to ~35s and intermittently
hit the server's query deadline, so the daily aggregator run survived on
retries. The exact `count(distinct: TransactionHeader_Hash)` was the heaviest
case and still timed out occasionally even after Bitquery extended the
server-side deadline.

## Changes
- All Trades-cube queries (volume, transactions, traders, DEX count) now
  filter on `Block.Date` with inclusive bounds — the query shape recommended
  by Bitquery — instead of `Block.Time` instants. The SOL price query
  (Tokens cube) is unchanged.
- `defi_dex_transactions` now uses `uniq(of: TransactionHeader_Hash,
  method: approximate)` instead of an exact distinct count; the methodology
  string discloses the approximation.

## Validation
- Approximation error measured against exact counts over 6 full days:
  0.02–0.18%.
- Full 7-day fetch of all five metrics: ~37s total with zero timeouts
  (volume 7.7s, transactions 15.2s, traders 4.3s, DEX count 9.1s,
  SOL price 0.3s); values identical to the currently published ones
  (volume $6.7–7.8B/day, in line with other providers on solana.com/data).
- Unit tests 13/13 (3 new: date-bound shape, approximate-uniq aggregate,
  price-query instant bounds); live integration tests 3/3; ruff and black
  clean.